### PR TITLE
Basic ability to add test cases from the inputs panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13290,6 +13290,7 @@
         "react-dom": "^18.2.0",
         "recoil": "^0.7.7",
         "recoil-sync": "^0.2.0",
+        "ts-essentials": "^9.3.1",
         "ts-loader": "^9.4.2",
         "webpack": "^5.76.3"
       },

--- a/vsc-extension/.eslintrc.json
+++ b/vsc-extension/.eslintrc.json
@@ -6,6 +6,13 @@
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "globals": { "acquireVsCodeApi": true },
+
   "rules": {
     "@typescript-eslint/naming-convention": [
       "warn",

--- a/vsc-extension/.eslintrc.json
+++ b/vsc-extension/.eslintrc.json
@@ -7,7 +7,13 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
-    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        "selector": "function",
+        "format": ["PascalCase", "camelCase"]
+      }
+    ],
     "@typescript-eslint/semi": "warn",
     "curly": "warn",
     "eqeqeq": "warn",

--- a/vsc-extension/.eslintrc.json
+++ b/vsc-extension/.eslintrc.json
@@ -6,7 +6,11 @@
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint"],
-  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
   "env": {
     "browser": true,
     "node": true

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -70,6 +70,7 @@
     "react-dom": "^18.2.0",
     "recoil": "^0.7.7",
     "recoil-sync": "^0.2.0",
+    "ts-essentials": "^9.3.1",
     "ts-loader": "^9.4.2",
     "webpack": "^5.76.3"
   },

--- a/vsc-extension/src-shared/messages.ts
+++ b/vsc-extension/src-shared/messages.ts
@@ -1,0 +1,25 @@
+import {
+  MaybeSelectedFunction,
+  SerializableSourceFileMap,
+  SourceFileTestCases,
+} from "./source-info";
+
+export interface UpdateSourcesMessage {
+  id: "update-sources";
+  params: [Readonly<SerializableSourceFileMap>];
+}
+
+export interface UpdateSelectionMessage {
+  id: "update-selection";
+  params: [MaybeSelectedFunction];
+}
+
+export interface UpdateTestCasesMessage {
+  id: "update-testcases";
+  params: [SourceFileTestCases[]];
+}
+
+export type ImaginaryMessage =
+  | UpdateSelectionMessage
+  | UpdateSourcesMessage
+  | UpdateTestCasesMessage;

--- a/vsc-extension/src-shared/messages.ts
+++ b/vsc-extension/src-shared/messages.ts
@@ -1,7 +1,7 @@
 import {
   MaybeSelectedFunction,
   SerializableSourceFileMap,
-  SourceFileTestCases,
+  SourceFileTestCaseMap,
 } from "./source-info";
 
 export interface UpdateSourcesMessage {
@@ -16,7 +16,7 @@ export interface UpdateFunctionSelectionMessage {
 
 export interface UpdateTestCasesMessage {
   id: "update-testcases";
-  params: [SourceFileTestCases[]];
+  params: [SourceFileTestCaseMap];
 }
 
 export type ImaginaryMessage =

--- a/vsc-extension/src-shared/messages.ts
+++ b/vsc-extension/src-shared/messages.ts
@@ -9,8 +9,8 @@ export interface UpdateSourcesMessage {
   params: [Readonly<SerializableSourceFileMap>];
 }
 
-export interface UpdateSelectionMessage {
-  id: "update-selection";
+export interface UpdateFunctionSelectionMessage {
+  id: "update-function-selection";
   params: [MaybeSelectedFunction];
 }
 
@@ -20,6 +20,6 @@ export interface UpdateTestCasesMessage {
 }
 
 export type ImaginaryMessage =
-  | UpdateSelectionMessage
+  | UpdateFunctionSelectionMessage
   | UpdateSourcesMessage
   | UpdateTestCasesMessage;

--- a/vsc-extension/src-shared/source-info.ts
+++ b/vsc-extension/src-shared/source-info.ts
@@ -26,6 +26,8 @@ export interface SourceFileTestCases {
   testCases: FunctionTestCases[];
 }
 
+export type SourceFileTestCaseMap = Record<string, SourceFileTestCases>;
+
 export interface SourceFileInfo {
   sourceFile: ts.SourceFile;
   functions: ts.FunctionDeclaration[];

--- a/vsc-extension/src-shared/source-info.ts
+++ b/vsc-extension/src-shared/source-info.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 
 export interface FunctionTestCase {
   /** Map of parameter name => value */
+  name: string;
   inputs: Record<string, any>;
   /**
    * The outputs from running the function with these inputs
@@ -23,7 +24,7 @@ export interface FunctionTestCases {
 /** Wrapper for all test cases in a given file */
 export interface SourceFileTestCases {
   sourceFileName: string;
-  testCases: FunctionTestCases[];
+  functionTestCases: FunctionTestCases[];
 }
 
 export type SourceFileTestCaseMap = Record<string, SourceFileTestCases>;

--- a/vsc-extension/src-shared/source-info.ts
+++ b/vsc-extension/src-shared/source-info.ts
@@ -37,6 +37,9 @@ export type SourceFileMap = Record<string, SourceFileInfo>;
 interface SerializableFunctionDeclaration {
   name?: string;
   declaration: string;
+  parameters: {
+    name: string;
+  }[];
 }
 
 interface SerializableSourceFile {
@@ -83,6 +86,14 @@ export function makeSerializable(
                   fn,
                   sourceFileInfo.sourceFile
                 ),
+                parameters: fn.parameters.map((param) => {
+                  return {
+                    name:
+                      param.name.kind === ts.SyntaxKind.Identifier
+                        ? param.name.escapedText.toString()
+                        : "<unknown>",
+                  };
+                }),
               };
             }
           ),

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -36,7 +36,10 @@ function addTestCaseToFile(
     ({ functionName }) => functionName === targetFunctionName
   );
   if (!matchingFunctionTestCases) {
-    return [{ functionName: targetFunctionName, testCases: [newTestCase] }];
+    return [
+      ...functionTestCases,
+      { functionName: targetFunctionName, testCases: [newTestCase] },
+    ];
   }
   return functionTestCases.map((prevFunctionTestCase: FunctionTestCases) =>
     addTestCaseToFunction(prevFunctionTestCase, targetFunctionName, newTestCase)

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -1,0 +1,66 @@
+import {
+  FunctionTestCase,
+  FunctionTestCases,
+  SourceFileTestCaseMap,
+} from "./source-info";
+
+export function addFunctionTestCase(
+  testCases: SourceFileTestCaseMap,
+  sourceFileName: string,
+  functionName: string,
+  newTestCase: FunctionTestCase
+): SourceFileTestCaseMap {
+  const fileTestCases = testCases[sourceFileName] ?? {
+    sourceFileName,
+    functionTestCases: [],
+  };
+
+  return {
+    ...testCases,
+    [sourceFileName]: {
+      ...fileTestCases,
+      functionTestCases: addTestCaseToFile(
+        fileTestCases.functionTestCases,
+        functionName,
+        newTestCase
+      ),
+    },
+  };
+}
+function addTestCaseToFile(
+  functionTestCases: FunctionTestCases[],
+  targetFunctionName: string,
+  newTestCase: FunctionTestCase
+): FunctionTestCases[] {
+  const matchingFunctionTestCases = functionTestCases.find(
+    ({ functionName }) => functionName === targetFunctionName
+  );
+  if (!matchingFunctionTestCases) {
+    return [{ functionName: targetFunctionName, testCases: [newTestCase] }];
+  }
+  return functionTestCases.map((prevFunctionTestCase: FunctionTestCases) =>
+    addTestCaseToFunction(prevFunctionTestCase, targetFunctionName, newTestCase)
+  );
+}
+function addTestCaseToFunction(
+  prevFunctionTestCase: FunctionTestCases,
+  functionName: string,
+  newTestCase: FunctionTestCase
+) {
+  if (prevFunctionTestCase.functionName === functionName) {
+    return {
+      ...prevFunctionTestCase,
+      testCases: [...prevFunctionTestCase.testCases, newTestCase],
+    };
+  }
+  return prevFunctionTestCase;
+}
+export function findTestCases(
+  testCases: SourceFileTestCaseMap,
+  fileName: string,
+  functionNameTarget: string
+) {
+  return testCases[fileName]?.functionTestCases.find(
+    ({ functionName }) => functionName === functionNameTarget
+  );
+}

--- a/vsc-extension/src-views/function-panel/App.tsx
+++ b/vsc-extension/src-views/function-panel/App.tsx
@@ -12,7 +12,6 @@ import {
   useExtensionState,
 } from "../shared/ExtensionState";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const App = () => {
   return (
     <RecoilRoot>

--- a/vsc-extension/src-views/function-panel/App.tsx
+++ b/vsc-extension/src-views/function-panel/App.tsx
@@ -1,76 +1,16 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import {
-  VSCodeButton,
-  VSCodeDataGrid,
-  VSCodeDataGridCell,
-  VSCodeDataGridRow,
-} from "@vscode/webview-ui-toolkit/react";
-import React, { useState } from "react";
+import React from "react";
 import { RecoilRoot } from "recoil";
-import {
-  ExtensionStateProvider,
-  useExtensionState,
-} from "../shared/ExtensionState";
+import { ExtensionStateProvider } from "../shared/ExtensionState";
+import { OutputPanel } from "../shared/OutputPanel";
 
 const App = () => {
   return (
     <RecoilRoot>
       <ExtensionStateProvider>
-        <AppInternal />
+        <OutputPanel />
       </ExtensionStateProvider>
     </RecoilRoot>
   );
 };
-
-function AppInternal() {
-  const { sendMessage, sources, selectedFunction } = useExtensionState();
-
-  const matchingSignatures = Object.values(sources)
-    .flatMap((sourceFileInfo) =>
-      sourceFileInfo.functions.map((fn) => {
-        if (fn.name === selectedFunction?.functionName) {
-          return fn.declaration;
-        }
-      })
-    )
-    .filter((s): s is string => !!s);
-  const [debug, setDebug] = useState(false);
-
-  return (
-    <>
-      {!!matchingSignatures.length && (
-        <>
-          <p>Function:</p>
-          {matchingSignatures.map((signature) => (
-            <code key="signature" style={{ whiteSpace: "nowrap" }}>
-              {signature}
-            </code>
-          ))}
-        </>
-      )}
-      <VSCodeDataGrid gridTemplateColumns="2fr 1fr 1fr" generateHeader="sticky">
-        <VSCodeDataGridRow rowType="sticky-header">
-          <VSCodeDataGridCell cellType="columnheader" gridColumn="1">
-            Inputs
-          </VSCodeDataGridCell>
-          <VSCodeDataGridCell cellType="columnheader" gridColumn="2">
-            Previous Outputs
-          </VSCodeDataGridCell>
-          <VSCodeDataGridCell cellType="columnheader" gridColumn="3">
-            Output
-          </VSCodeDataGridCell>
-        </VSCodeDataGridRow>
-      </VSCodeDataGrid>
-
-      <VSCodeButton
-        appearance="icon"
-        onClick={() => setDebug((prevDebug) => !prevDebug)}
-      >
-        <span>🐛</span>
-      </VSCodeButton>
-      {debug && <pre>{JSON.stringify(sources, null, 4)}</pre>}
-    </>
-  );
-}
 
 export default App;

--- a/vsc-extension/src-views/input-panel/App.tsx
+++ b/vsc-extension/src-views/input-panel/App.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 type Props = {};
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const App = (props: Props) => {
   return <div>This is the inputs panel</div>;
 };

--- a/vsc-extension/src-views/input-panel/App.tsx
+++ b/vsc-extension/src-views/input-panel/App.tsx
@@ -1,9 +1,16 @@
 import React from "react";
+import { RecoilRoot } from "recoil";
+import { ExtensionStateProvider } from "../shared/ExtensionState";
+import { InputPanel } from "../shared/InputPanel";
 
-type Props = {};
-
-const App = (props: Props) => {
-  return <div>This is the inputs panel</div>;
+const App = () => {
+  return (
+    <RecoilRoot>
+      <ExtensionStateProvider>
+        <InputPanel />
+      </ExtensionStateProvider>
+    </RecoilRoot>
+  );
 };
 
 export default App;

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -27,7 +27,11 @@ function useExtensionStateInternal() {
   useEffect(() => {
     window.addEventListener("message", (event) => {
       const message: ImaginaryMessage = event.data;
-      console.log(`[${this.viewId}] Got ${message.id}`);
+
+      console.log(
+        `[${window.location}] Got ${message.id} from ${event.origin} /`,
+        event
+      );
 
       switch (message.id) {
         case "update-sources": {

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -38,12 +38,10 @@ function useExtensionStateInternal() {
           const [sources] = message.params;
           console.log("got sources: ", sources);
           return setSources(sources);
-          break;
         }
         case "update-function-selection": {
           const [selection] = message.params;
           return setSelectedFunction(selection);
-          break;
         }
         case "update-testcases": {
           const [testCases] = message.params;

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -74,6 +74,12 @@ function useExtensionStateInternal() {
     },
     []
   );
+
+  // TODO: this boilerplate sucks. We don't get rebroadcast that stuff has
+  // changed, so we need to update local state instead. It would be better to
+  // automatically send the update message when `setTestCases` is called. This
+  // is a good place to integrate recoil/recoil-sync or another stateful library
+  // that can persist state
   const updateTestCases = useCallback(
     (newTestCases: SourceFileTestCaseMap) => {
       sendMessage("update-testcases", newTestCases);

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -36,7 +36,7 @@ function useExtensionStateInternal() {
           return setSources(sources);
           break;
         }
-        case "update-selection": {
+        case "update-function-selection": {
           const [selection] = message.params;
           return setSelectedFunction(selection);
           break;

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -12,7 +12,7 @@ import { ImaginaryMessage } from "../../src-shared/messages";
 import {
   MaybeSelectedFunction,
   SerializableSourceFileMap,
-  SourceFileTestCases,
+  SourceFileTestCaseMap,
 } from "../../src-shared/source-info";
 
 /** Main hook that wires up all messaging to/from this webview */
@@ -21,7 +21,7 @@ function useExtensionStateInternal() {
   const [sources, setSources] = useState<SerializableSourceFileMap>({});
   const [selectedFunction, setSelectedFunction] =
     useState<MaybeSelectedFunction>(null);
-  const [testCases, setTestCases] = useState<SourceFileTestCases[]>([]);
+  const [testCases, setTestCases] = useState<SourceFileTestCaseMap>({});
 
   // Synchronize states by listening for events
   useEffect(() => {
@@ -65,7 +65,7 @@ function useExtensionStateInternal() {
     },
     []
   );
-  return { sendMessage, sources, selectedFunction };
+  return { sendMessage, sources, selectedFunction, testCases };
 }
 
 const ExtensionState = createContext<
@@ -73,6 +73,7 @@ const ExtensionState = createContext<
 >({
   selectedFunction: null,
   sources: {},
+  testCases: {},
   sendMessage: () => {},
 });
 

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -33,7 +33,7 @@ function useExtensionStateInternal() {
       const message: ImaginaryMessage = event.data;
 
       console.log(
-        `[${window.location}] Got ${message.id} from ${event.origin} /`,
+        `[${window.origin}] Got ${message.id} from ${event.origin} /`,
         event
       );
 

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import React, {
   createContext,
   FC,

--- a/vsc-extension/src-views/shared/ExtensionState.tsx
+++ b/vsc-extension/src-views/shared/ExtensionState.tsx
@@ -28,6 +28,8 @@ function useExtensionStateInternal() {
   useEffect(() => {
     window.addEventListener("message", (event) => {
       const message: ImaginaryMessage = event.data;
+      console.log(`[${this.viewId}] Got ${message.id}`);
+
       switch (message.id) {
         case "update-sources": {
           const [sources] = message.params;

--- a/vsc-extension/src-views/shared/InputPanel.tsx
+++ b/vsc-extension/src-views/shared/InputPanel.tsx
@@ -1,7 +1,34 @@
 import React from "react";
+import { useExtensionState } from "./ExtensionState";
 
-type Props = {};
+export const InputPanel = () => {
+  const { selectedFunction, testCases } = useExtensionState();
 
-export const InputPanel = (props: Props) => {
-  return <div>InputPanel</div>;
+  if (!selectedFunction) {
+    return <p>No function selected</p>;
+  }
+  const functionTestCases = testCases[
+    selectedFunction.fileName
+  ]?.testCases.find(
+    ({ functionName }) => selectedFunction.functionName === functionName
+  );
+  return (
+    <div>
+      <p>Test cases for {selectedFunction.functionName}</p>
+      {!functionTestCases && (
+        <p>
+          <i>No test cases yet</i>
+        </p>
+      )}
+      {!!functionTestCases && (
+        <ul>
+          {functionTestCases.testCases.map((testCase, index) => (
+            <pre key={index}>{JSON.stringify(testCase.inputs)}</pre>
+          ))}
+          <li></li>
+        </ul>
+      )}
+      <pre></pre>
+    </div>
+  );
 };

--- a/vsc-extension/src-views/shared/InputPanel.tsx
+++ b/vsc-extension/src-views/shared/InputPanel.tsx
@@ -30,12 +30,6 @@ export const InputPanel = () => {
   const { fileName, functionName } = selectedFunction;
   const functionTestCases = findTestCases(testCases, fileName, functionName);
 
-  console.log(
-    "have functionTestCases: ",
-    functionTestCases,
-    " from ",
-    testCases
-  );
   return (
     <div>
       <p>Test cases for {selectedFunction.functionName}</p>

--- a/vsc-extension/src-views/shared/InputPanel.tsx
+++ b/vsc-extension/src-views/shared/InputPanel.tsx
@@ -1,16 +1,40 @@
-import React from "react";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import React, { useCallback } from "react";
+import { FunctionTestCase } from "../../src-shared/source-info";
+import { addFunctionTestCase, findTestCases } from "../../src-shared/testcases";
 import { useExtensionState } from "./ExtensionState";
 
 export const InputPanel = () => {
-  const { selectedFunction, testCases } = useExtensionState();
+  const { selectedFunction, testCases, updateTestCases } = useExtensionState();
 
+  const onAddTestCase = useCallback(() => {
+    if (!selectedFunction) {
+      return;
+    }
+    const { fileName, functionName } = selectedFunction;
+    const newTestCase: FunctionTestCase = {
+      name: "New test",
+      inputs: {},
+      output: {
+        prev: {},
+        current: {},
+      },
+    };
+    updateTestCases(
+      addFunctionTestCase(testCases, fileName, functionName, newTestCase)
+    );
+  }, [selectedFunction, updateTestCases, testCases]);
   if (!selectedFunction) {
     return <p>No function selected</p>;
   }
-  const functionTestCases = testCases[
-    selectedFunction.fileName
-  ]?.testCases.find(
-    ({ functionName }) => selectedFunction.functionName === functionName
+  const { fileName, functionName } = selectedFunction;
+  const functionTestCases = findTestCases(testCases, fileName, functionName);
+
+  console.log(
+    "have functionTestCases: ",
+    functionTestCases,
+    " from ",
+    testCases
   );
   return (
     <div>
@@ -21,14 +45,15 @@ export const InputPanel = () => {
         </p>
       )}
       {!!functionTestCases && (
-        <ul>
+        <ol>
           {functionTestCases.testCases.map((testCase, index) => (
-            <pre key={index}>{JSON.stringify(testCase.inputs)}</pre>
+            <li key={index}>
+              <pre>{JSON.stringify(testCase.inputs)}</pre>
+            </li>
           ))}
-          <li></li>
-        </ul>
+        </ol>
       )}
-      <pre></pre>
+      <VSCodeButton onClick={onAddTestCase}>Add test case</VSCodeButton>
     </div>
   );
 };

--- a/vsc-extension/src-views/shared/InputPanel.tsx
+++ b/vsc-extension/src-views/shared/InputPanel.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+type Props = {};
+
+export const InputPanel = (props: Props) => {
+  return <div>InputPanel</div>;
+};

--- a/vsc-extension/src-views/shared/OutputPanel.tsx
+++ b/vsc-extension/src-views/shared/OutputPanel.tsx
@@ -1,0 +1,59 @@
+import {
+  VSCodeButton,
+  VSCodeDataGrid,
+  VSCodeDataGridCell,
+  VSCodeDataGridRow,
+} from "@vscode/webview-ui-toolkit/react";
+import React, { useState } from "react";
+import { useExtensionState } from "./ExtensionState";
+
+export function OutputPanel() {
+  const { sendMessage, sources, selectedFunction } = useExtensionState();
+
+  const matchingSignatures = Object.values(sources)
+    .flatMap((sourceFileInfo) =>
+      sourceFileInfo.functions.map((fn) => {
+        if (fn.name === selectedFunction?.functionName) {
+          return fn.declaration;
+        }
+      })
+    )
+    .filter((s): s is string => !!s);
+  const [debug, setDebug] = useState(false);
+
+  return (
+    <>
+      {!!matchingSignatures.length && (
+        <>
+          <p>Function:</p>
+          {matchingSignatures.map((signature) => (
+            <code key="signature" style={{ whiteSpace: "nowrap" }}>
+              {signature}
+            </code>
+          ))}
+        </>
+      )}
+      <VSCodeDataGrid gridTemplateColumns="2fr 1fr 1fr" generateHeader="sticky">
+        <VSCodeDataGridRow rowType="sticky-header">
+          <VSCodeDataGridCell cellType="columnheader" gridColumn="1">
+            Inputs
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell cellType="columnheader" gridColumn="2">
+            Previous Outputs
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell cellType="columnheader" gridColumn="3">
+            Output
+          </VSCodeDataGridCell>
+        </VSCodeDataGridRow>
+      </VSCodeDataGrid>
+
+      <VSCodeButton
+        appearance="icon"
+        onClick={() => setDebug((prevDebug) => !prevDebug)}
+      >
+        <span>🐛</span>
+      </VSCodeButton>
+      {debug && <pre>{JSON.stringify(sources, null, 4)}</pre>}
+    </>
+  );
+}

--- a/vsc-extension/src-views/shared/OutputPanel.tsx
+++ b/vsc-extension/src-views/shared/OutputPanel.tsx
@@ -8,7 +8,7 @@ import React, { useState } from "react";
 import { useExtensionState } from "./ExtensionState";
 
 export function OutputPanel() {
-  const { sendMessage, sources, selectedFunction } = useExtensionState();
+  const { sources, selectedFunction } = useExtensionState();
 
   const matchingSignatures = Object.values(sources)
     .flatMap((sourceFileInfo) =>

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import {
   MaybeSelectedFunction,
   SourceFileMap,
+  SourceFileTestCases,
 } from "../src-shared/source-info";
 import { ImaginaryFunctionProvider } from "./function-tree-provider";
 import { ImaginaryMessageRouter } from "./imaginary-message-router";
@@ -53,6 +54,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
   // These are all the local states in the extension.
   let sources: Readonly<SourceFileMap> = {};
   let selectedFunction: MaybeSelectedFunction = null;
+  let testCases: SourceFileTestCases[] = [];
 
   const functionTreeProvider = new ImaginaryFunctionProvider(sources);
   const treeView = vscode.window.createTreeView("functions", {

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -49,6 +49,9 @@ export function activate(extensionContext: vscode.ExtensionContext) {
   extensionContext.subscriptions.push(
     messageRouter.onDidReceiveMessage((webviewMessage) => {
       const { message, webviewProvider } = webviewMessage;
+      console.log(
+        `[extension] Got ${message.id} from ${webviewProvider.viewId}`
+      );
       switch (message.id) {
         case "update-sources":
           throw new Error("Only core extension is allowed to update sources");
@@ -65,7 +68,6 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         default:
           throw new UnreachableCaseError(message);
       }
-      console.log("got message from webview: ", webviewMessage.message);
     })
   );
 

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -77,7 +77,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
   let testCases: SourceFileTestCases[] = [];
 
   const functionTreeProvider = new ImaginaryFunctionProvider(sources);
-  const treeView = vscode.window.createTreeView("functions", {
+  vscode.window.createTreeView("functions", {
     treeDataProvider: functionTreeProvider,
   });
   vscode.commands.registerCommand("imaginary.clickFunction", focusNode);

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 import {
   MaybeSelectedFunction,
   SourceFileMap,
-  SourceFileTestCases,
+  SourceFileTestCaseMap,
 } from "../src-shared/source-info";
 import { ImaginaryFunctionProvider } from "./function-tree-provider";
 import { ImaginaryMessageRouter } from "./imaginary-message-router";
@@ -56,15 +56,16 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         case "update-sources":
           throw new Error("Only core extension is allowed to update sources");
         case "update-function-selection":
+          selectedFunction = message.params[0];
           return messageRouter.updateFunctionSelection(
-            message.params[0],
+            selectedFunction,
             webviewProvider
           );
+
         case "update-testcases":
-          return messageRouter.updateTestCases(
-            message.params[0],
-            webviewProvider
-          );
+          testCases = message.params[0];
+          return messageRouter.updateTestCases(testCases, webviewProvider);
+
         default:
           throw new UnreachableCaseError(message);
       }
@@ -74,7 +75,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
   // These are all the local states in the extension.
   let sources: Readonly<SourceFileMap> = {};
   let selectedFunction: MaybeSelectedFunction = null;
-  let testCases: SourceFileTestCases[] = [];
+  let testCases: Readonly<SourceFileTestCaseMap> = {};
 
   const functionTreeProvider = new ImaginaryFunctionProvider(sources);
   vscode.window.createTreeView("functions", {

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -55,8 +55,8 @@ export function activate(extensionContext: vscode.ExtensionContext) {
       switch (message.id) {
         case "update-sources":
           throw new Error("Only core extension is allowed to update sources");
-        case "update-selection":
-          return messageRouter.updateSelection(
+        case "update-function-selection":
+          return messageRouter.updateFunctionSelection(
             message.params[0],
             webviewProvider
           );
@@ -158,7 +158,7 @@ function updateViewsWithSelection(
   );
   if (newSelection !== selectedFunction) {
     selectedFunction = newSelection;
-    messageRouter.updateSelection(newSelection);
+    messageRouter.updateFunctionSelection(newSelection);
   }
   return selectedFunction;
 }

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -126,7 +126,6 @@ export function activate(extensionContext: vscode.ExtensionContext) {
     sources,
     messageRouter
   );
-  probe();
 }
 
 function initializeSelection(
@@ -185,18 +184,3 @@ function initializeOpenEditors(
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
-
-async function probe() {
-  const typeScriptExtensionId = "vscode.typescript-language-features";
-  const extension = vscode.extensions.getExtension(typeScriptExtensionId);
-  if (!extension) {
-    console.log("cannot find extension");
-    return;
-  }
-  if (!extension.isActive) {
-    await extension.activate();
-  }
-  const api = extension.exports.getAPI(0);
-  const p = api.configurePlugin("imaginary-programming", { port: 12345 });
-  console.log("has api: ", api);
-}

--- a/vsc-extension/src/imaginary-message-router.ts
+++ b/vsc-extension/src/imaginary-message-router.ts
@@ -4,7 +4,7 @@ import {
   makeSerializable,
   MaybeSelectedFunction,
   SourceFileMap,
-  SourceFileTestCases,
+  SourceFileTestCaseMap,
 } from "../src-shared/source-info";
 import { ReactWebViewProvider } from "./util/react-webview-provider";
 
@@ -73,7 +73,7 @@ export class ImaginaryMessageRouter {
   }
 
   async updateTestCases(
-    testCases: SourceFileTestCases[],
+    testCases: SourceFileTestCaseMap,
     ignoreProvider?: ReactWebViewProvider
   ) {
     return this.postMessage("update-testcases", [testCases], ignoreProvider);

--- a/vsc-extension/src/imaginary-message-router.ts
+++ b/vsc-extension/src/imaginary-message-router.ts
@@ -38,14 +38,12 @@ export class ImaginaryMessageRouter {
           })
         );
       });
-      const detatchDisposable = webviewProvider.onDidDetatchWebview(
-        (webview) => {
-          // TODO: dispose of attached onDidReceiveMessage disposable
-          this.attachedWebviewProviders = this.attachedWebviewProviders.filter(
-            (provider) => provider !== webviewProvider
-          );
-        }
-      );
+      const detatchDisposable = webviewProvider.onDidDetatchWebview(() => {
+        // TODO: dispose of attached onDidReceiveMessage disposable
+        this.attachedWebviewProviders = this.attachedWebviewProviders.filter(
+          (provider) => provider !== webviewProvider
+        );
+      });
       return [attachDisposable, detatchDisposable];
     });
     this.disposables.push(vscode.Disposable.from(...disposables));

--- a/vsc-extension/src/imaginary-message-router.ts
+++ b/vsc-extension/src/imaginary-message-router.ts
@@ -1,21 +1,25 @@
 import * as vscode from "vscode";
+import { ImaginaryMessage } from "../src-shared/messages";
 import {
   makeSerializable,
   MaybeSelectedFunction,
   SourceFileMap,
+  SourceFileTestCases,
 } from "../src-shared/source-info";
 import { ReactWebViewProvider } from "./util/react-webview-provider";
 
 /** A message router to broadcast and recieve messages from multiple webviews */
 
-export interface WebviewMessage<T = any> {
+export interface WebviewMessage<M extends ImaginaryMessage> {
   webviewProvider: ReactWebViewProvider;
-  message: T;
+  message: M;
 }
 export class ImaginaryMessageRouter {
   webviewProviders: readonly ReactWebViewProvider[];
   disposables: vscode.Disposable[] = [];
-  private _onDidReceiveMessage = new vscode.EventEmitter<WebviewMessage>();
+  private _onDidReceiveMessage = new vscode.EventEmitter<
+    WebviewMessage<ImaginaryMessage>
+  >();
   onDidReceiveMessage = this._onDidReceiveMessage.event;
   constructor(webviewProviders: readonly ReactWebViewProvider[]) {
     this.webviewProviders = webviewProviders;
@@ -39,24 +43,47 @@ export class ImaginaryMessageRouter {
     d.dispose();
   }
 
-  async updateSources(sources: SourceFileMap) {
+  async updateSources(
+    sources: Readonly<SourceFileMap>,
+    ignoreProvider?: ReactWebViewProvider
+  ) {
     const serialized = makeSerializable(sources);
-    this.postMessage("update-sources", serialized);
+    return this.postMessage("update-sources", [serialized], ignoreProvider);
   }
 
-  async updateSelection(selection: MaybeSelectedFunction) {
-    this.postMessage("update-selection", selection);
+  async updateSelection(
+    selection: MaybeSelectedFunction,
+    ignoreProvider?: ReactWebViewProvider
+  ) {
+    return this.postMessage("update-selection", [selection], ignoreProvider);
   }
 
-  async postMessage<T extends any[]>(messageId: string, ...params: T) {
-    this.webviewProviders.forEach((provider) => {
+  async updateTestCases(
+    testCases: SourceFileTestCases[],
+    ignoreProvider?: ReactWebViewProvider
+  ) {
+    return this.postMessage("update-testcases", [testCases], ignoreProvider);
+  }
+
+  async postMessage<
+    M extends ImaginaryMessage,
+    K extends M["id"],
+    T extends M["params"]
+  >(messageId: K, params: T, ignoreWebview?: ReactWebViewProvider) {
+    const result = this.webviewProviders.map((provider) => {
       if (!provider.webviewView) {
         throw new Error("webview has not been initialized");
       }
-      return provider.webviewView.webview.postMessage({
+      // Avoids broadcast feedback loops
+      if (provider === ignoreWebview) {
+        return true;
+      }
+      const message = {
         id: messageId,
         params,
-      });
+      } as ImaginaryMessage;
+      return provider.webviewView.webview.postMessage(message);
     });
+    return Promise.allSettled(result);
   }
 }

--- a/vsc-extension/src/imaginary-message-router.ts
+++ b/vsc-extension/src/imaginary-message-router.ts
@@ -51,11 +51,15 @@ export class ImaginaryMessageRouter {
     return this.postMessage("update-sources", [serialized], ignoreProvider);
   }
 
-  async updateSelection(
+  async updateFunctionSelection(
     selection: MaybeSelectedFunction,
     ignoreProvider?: ReactWebViewProvider
   ) {
-    return this.postMessage("update-selection", [selection], ignoreProvider);
+    return this.postMessage(
+      "update-function-selection",
+      [selection],
+      ignoreProvider
+    );
   }
 
   async updateTestCases(

--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -16,7 +16,9 @@ export function registerWebView(
 /** Generic WebviewViewProvider which wraps a react application */
 export class ReactWebViewProvider implements vscode.WebviewViewProvider {
   private _onDidAttachWebview = new vscode.EventEmitter<vscode.Webview>();
+  private _onDidDetatchWebview = new vscode.EventEmitter<vscode.Webview>();
   onDidAttachWebview = this._onDidAttachWebview.event;
+  onDidDetatchWebview = this._onDidDetatchWebview.event;
   viewId: string;
   extensionUri: vscode.Uri;
   webviewView?: vscode.WebviewView;
@@ -30,6 +32,10 @@ export class ReactWebViewProvider implements vscode.WebviewViewProvider {
     context: vscode.WebviewViewResolveContext,
     token: vscode.CancellationToken
   ) {
+    token.onCancellationRequested((e) => {
+      console.log("disposing of provider", this.viewId);
+      this._onDidDetatchWebview.fire(e);
+    });
     const extensionRoot = vscode.Uri.joinPath(this.extensionUri, "dist");
     this.webviewView = webviewView;
     webviewView.webview.options = {

--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -50,7 +50,7 @@ export class ReactWebViewProvider implements vscode.WebviewViewProvider {
     const webViewHtml = html`
       <html lang="en">
         <head>
-          <title>Foo</title>
+          <title>React Webview Provider: ${this.viewId}</title>
           <meta
             http-equiv="Content-Security-Policy"
             content="default-src 'none'; img-src vscode-resource: https:; script-src 'nonce-${nonce}';style-src vscode-resource: 'unsafe-inline' http: https: data:;"

--- a/vsc-extension/webpack.config.js
+++ b/vsc-extension/webpack.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 //@ts-check
 
 "use strict";


### PR DESCRIPTION
- bring in test cases as local state
- unify messages
- add ts-essentials
- formalize message dispatching from webview -> extension -> webview
- better logging
- fix eslint naming
- unified infra for both panels
- rename update selection -> update function selection
- better console logging when messages com in
- better tracking of webviews detatching
- better title
- add some lint, clean some code
- switch test cases map to resmble function map
- oops debug code
- initial test case panel
- stub out parameters in serialized declaration
- add rules of hooks too
- wire up creating new test cases
- comment explaining whats going on
- oops, fix case of adding 2nd function
- better log?
- no logs
