### PR TITLE
Basic RPC between webview and extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
       "dependencies": {
         "dotenv": "^16.0.3",
         "json5": "^2.2.3",
-        "string-to-file-stream": "^1.3.0"
+        "string-to-file-stream": "^1.3.0",
+        "worker-rpc": "^0.2.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.3.1",
@@ -9369,6 +9370,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/microevent.ts": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.2.1.tgz",
+      "integrity": "sha512-YaOQr4V70QzTy3sTRkBUa7+clmN4rMdKs9L5wCCxYjo8gknO/FXhcEX5Pot4IWtAdiZqhxN7vskoywQbAOAkDQ=="
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -13027,6 +13033,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/worker-rpc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.2.0.tgz",
+      "integrity": "sha512-S74HnfAdmMlUYmr6+Lx6TmxvffM2vRZSk4RfI/Bxco4xZGw+FREzLRZhFxf8QIzI2/5NKNMn5+Pj69Bp+rweIg==",
+      "dependencies": {
+        "microevent.ts": "~0.2.1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "json5": "^2.2.3",
-    "string-to-file-stream": "^1.3.0"
+    "string-to-file-stream": "^1.3.0",
+    "worker-rpc": "^0.2.0"
   },
   "volta": {
     "node": "18.13.0",
     "npm": "9.5.1"
   }
 }
-

--- a/vsc-extension/src-shared/messages.ts
+++ b/vsc-extension/src-shared/messages.ts
@@ -1,3 +1,4 @@
+import { RpcProvider } from "worker-rpc";
 import {
   MaybeSelectedFunction,
   SerializableSourceFileMap,
@@ -19,7 +20,13 @@ export interface UpdateTestCasesMessage {
   params: [SourceFileTestCaseMap];
 }
 
+export interface RpcMessage {
+  id: "rpc";
+  params: [message: RpcProvider.Message, transfer?: any[]];
+}
+
 export type ImaginaryMessage =
   | UpdateFunctionSelectionMessage
   | UpdateSourcesMessage
-  | UpdateTestCasesMessage;
+  | UpdateTestCasesMessage
+  | RpcMessage;

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -65,6 +65,10 @@ export function activate(extensionContext: vscode.ExtensionContext) {
         case "update-testcases":
           testCases = message.params[0];
           return messageRouter.updateTestCases(testCases, webviewProvider);
+        case "rpc": {
+          // ignore them here, they will be handled outside this router
+          return null;
+        }
 
         default:
           throw new UnreachableCaseError(message);

--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -92,7 +92,7 @@ export class ReactWebViewProvider implements vscode.WebviewViewProvider {
     this._onDidAttachWebview.fire(webviewView.webview);
   }
 }
-export function getNonce() {
+function getNonce() {
   let text = "";
   const possible =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";


### PR DESCRIPTION
- add worker-rpc to experiment with 2-way rpc
- add new rpc message
- handle rpc messages in webviews
- ignore rpc messages from message router, these need to be handled by the webviewprovider
- deal with extension-side rpc with each webviewprovider
- no need to export
