### PR TITLE
Wire up initial RPC-based recoil syncing, just for debug state

### DIFF
--- a/vsc-extension/src-views/function-panel/App.tsx
+++ b/vsc-extension/src-views/function-panel/App.tsx
@@ -2,12 +2,15 @@ import React from "react";
 import { RecoilRoot } from "recoil";
 import { ExtensionStateProvider } from "../shared/ExtensionState";
 import { OutputPanel } from "../shared/OutputPanel";
+import { RecoilSyncWebview } from "../shared/RecoilSyncWebview";
 
 const App = () => {
   return (
     <RecoilRoot>
       <ExtensionStateProvider>
-        <OutputPanel />
+        <RecoilSyncWebview>
+          <OutputPanel />
+        </RecoilSyncWebview>
       </ExtensionStateProvider>
     </RecoilRoot>
   );

--- a/vsc-extension/src-views/input-panel/App.tsx
+++ b/vsc-extension/src-views/input-panel/App.tsx
@@ -2,15 +2,17 @@ import React from "react";
 import { RecoilRoot } from "recoil";
 import { ExtensionStateProvider } from "../shared/ExtensionState";
 import { InputPanel } from "../shared/InputPanel";
+import { RecoilSyncWebview } from "../shared/RecoilSyncWebview";
 
 const App = () => {
   return (
     <RecoilRoot>
       <ExtensionStateProvider>
-        <InputPanel />
+        <RecoilSyncWebview>
+          <InputPanel />
+        </RecoilSyncWebview>
       </ExtensionStateProvider>
     </RecoilRoot>
   );
 };
-
 export default App;

--- a/vsc-extension/src-views/shared/InputPanel.tsx
+++ b/vsc-extension/src-views/shared/InputPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from "@vscode/webview-ui-toolkit/react";
 import { produce } from "immer";
 import React, { useCallback, useState } from "react";
+import { useRecoilValue } from "recoil";
 import {
   FunctionTestCase,
   FunctionTestCases,
@@ -15,6 +16,7 @@ import {
 import { addFunctionTestCase, findTestCases } from "../../src-shared/testcases";
 import { findMatchingFunction } from "../../src/util/serialized-source";
 import { useExtensionState } from "./ExtensionState";
+import { debugState } from "./state";
 
 const emptyTestCase: FunctionTestCase = {
   inputs: {},
@@ -117,6 +119,8 @@ export const InputPanel = () => {
     },
     [updateTestCases]
   );
+  const isDebugMode = useRecoilValue(debugState);
+
   const onAddTestCase = useCallback(() => {
     if (!selectedFunction) {
       return;
@@ -138,6 +142,7 @@ export const InputPanel = () => {
     return <p>No function selected</p>;
   }
   const { fileName, functionName } = selectedFunction;
+
   const functionTestCases = findTestCases(testCases, fileName, functionName);
   const selectedFunctionInfo = findMatchingFunction(sources, selectedFunction);
   const selectedTestCase = functionTestCases?.testCases[selectedTestCaseIndex];
@@ -146,6 +151,7 @@ export const InputPanel = () => {
       <p>
         Test cases for <code>{selectedFunction.functionName}</code>
       </p>
+      <p>Debug state: {`${isDebugMode}`}</p>
       {!functionTestCases && (
         <p>
           <i>No test cases yet</i>

--- a/vsc-extension/src-views/shared/OutputPanel.tsx
+++ b/vsc-extension/src-views/shared/OutputPanel.tsx
@@ -4,15 +4,17 @@ import {
   VSCodeDataGridCell,
   VSCodeDataGridRow,
 } from "@vscode/webview-ui-toolkit/react";
-import React, { useState } from "react";
+import React from "react";
+import { useRecoilState } from "recoil";
 import { findMatchingFunction } from "../../src/util/serialized-source";
 import { useExtensionState } from "./ExtensionState";
+import { debugState } from "./state";
 
 export function OutputPanel() {
   const { sources, testCases, selectedFunction } = useExtensionState();
 
   const fn = findMatchingFunction(sources, selectedFunction);
-  const [debug, setDebug] = useState(false);
+  const [debug, setDebug] = useRecoilState(debugState);
 
   return (
     <>

--- a/vsc-extension/src-views/shared/RecoilSyncWebview.tsx
+++ b/vsc-extension/src-views/shared/RecoilSyncWebview.tsx
@@ -8,6 +8,10 @@ export const RecoilSyncWebview: FC<PropsWithChildren<{}>> = ({ children }) => {
   const { rpcProvider } = useExtensionState();
 
   const { reader, writer, listen } = useRpc(rpcProvider);
+  if (!rpcProvider) {
+    // do not render without an rpcProvider, because RecoilSync starts reading from the store immediately
+    return null;
+  }
   return (
     <RecoilSync read={reader} write={writer} listen={listen}>
       {children}
@@ -23,7 +27,10 @@ function useRpc(rpcProvider: RpcProvider | undefined): {
   return useMemo(() => {
     if (!rpcProvider) {
       return {
-        reader: () => new DefaultValue(),
+        reader: (itemKey) => {
+          console.warn(`[webview] reading ${itemKey} before provider is ready`);
+          return new DefaultValue();
+        },
         writer: () => {},
         listen: () => {},
       };

--- a/vsc-extension/src-views/shared/RecoilSyncWebview.tsx
+++ b/vsc-extension/src-views/shared/RecoilSyncWebview.tsx
@@ -1,0 +1,43 @@
+import React, { FC, PropsWithChildren, useMemo } from "react";
+import { ListenToItems, ReadItem, RecoilSync, WriteItems } from "recoil-sync";
+import { RpcProvider } from "worker-rpc";
+import { useExtensionState } from "./ExtensionState";
+
+export const RecoilSyncWebview: FC<PropsWithChildren<{}>> = ({ children }) => {
+  const { rpcProvider } = useExtensionState();
+
+  const { reader, writer, listen } = useRpc(rpcProvider);
+  return (
+    <RecoilSync read={reader} write={writer} listen={listen}>
+      {children}
+    </RecoilSync>
+  );
+};
+
+function useRpc(rpcProvider: RpcProvider | undefined): {
+  reader: ReadItem;
+  writer: WriteItems;
+  listen: ListenToItems;
+} {
+  return useMemo(() => {
+    const reader: ReadItem = async (itemKey) => {
+      return rpcProvider?.rpc("read-state", itemKey);
+    };
+    const writer: WriteItems = async ({ allItems }) => {
+      const entries = [...allItems];
+      const values = Object.fromEntries(entries);
+      return rpcProvider?.rpc("write-state", values);
+    };
+
+    // Note there is no unregister here
+    const listen: ListenToItems = ({ updateItems }) => {
+      rpcProvider?.registerRpcHandler<Record<string, any>, any>(
+        "update-state",
+        (values) => {
+          updateItems(new Map(Object.entries(values)));
+        }
+      );
+    };
+    return { reader, writer, listen };
+  }, [rpcProvider]);
+}

--- a/vsc-extension/src-views/shared/state.ts
+++ b/vsc-extension/src-views/shared/state.ts
@@ -1,0 +1,25 @@
+import { custom } from "@recoiljs/refine";
+import { atom, DefaultValue } from "recoil";
+import { syncEffect } from "recoil-sync";
+
+function synced<T>(defaultValue: T) {
+  return syncEffect<T>({
+    refine: custom((v) => {
+      console.log(
+        "refining ",
+        v,
+        "of type",
+        typeof v,
+        "def:",
+        v instanceof DefaultValue
+      );
+      return v instanceof DefaultValue ? defaultValue : (v as T);
+    }),
+  });
+}
+
+export const debugState = atom<boolean>({
+  default: false,
+  key: "app.debugMode",
+  effects: [synced(false)],
+});

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -31,6 +31,8 @@ export function activate(extensionContext: vscode.ExtensionContext) {
   );
 
   const state = new Map<string, any>();
+  // Set defaults so that recoil sync's custom() does not explode
+  state.set("app.debugMode", false);
 
   const outputsWebviewProvider = registerWebView(
     extensionContext,

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
   extensionContext.subscriptions.push(messageRouter);
 
   extensionContext.subscriptions.push(
-    messageRouter.onDidReceiveMessage((webviewMessage) => {
+    messageRouter.onDidReceiveMessage(async (webviewMessage) => {
       const { message, webviewProvider } = webviewMessage;
       console.log(
         `[extension] Got ${message.id} from ${webviewProvider.viewId}`

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -30,15 +30,19 @@ export function activate(extensionContext: vscode.ExtensionContext) {
     'Congratulations, your extension "imaginary-programming" is now active!'
   );
 
+  const state = new Map<string, any>();
+
   const outputsWebviewProvider = registerWebView(
     extensionContext,
     "imaginary.currentfunctions",
-    "function-panel"
+    "function-panel",
+    state
   );
   const inputsWebviewProvider = registerWebView(
     extensionContext,
     "imaginary.inputs",
-    "input-panel"
+    "input-panel",
+    state
   );
   const messageRouter = new ImaginaryMessageRouter([
     outputsWebviewProvider,

--- a/vsc-extension/src/imaginary-message-router.ts
+++ b/vsc-extension/src/imaginary-message-router.ts
@@ -34,7 +34,16 @@ export class ImaginaryMessageRouter {
         // TODO: dispose of attached onDidReceiveMessage disposable
         this._onDidDetachWebview(webviewProvider);
       });
-      return [attachDisposable, detatchDisposable];
+      const updateStateDisposable = webviewProvider.onDidUpdateState(
+        ({ webview, diff }) => {
+          this.attachedWebviewProviders.forEach((provider) => {
+            if (provider.webviewView?.webview !== webview) {
+              provider.sendStateUpdate(diff);
+            }
+          });
+        }
+      );
+      return [attachDisposable, detatchDisposable, updateStateDisposable];
     });
     this.disposables.push(...disposables);
   }

--- a/vsc-extension/src/imaginary-message-router.ts
+++ b/vsc-extension/src/imaginary-message-router.ts
@@ -36,17 +36,26 @@ export class ImaginaryMessageRouter {
       });
       const updateStateDisposable = webviewProvider.onDidUpdateState(
         ({ webview, diff }) => {
-          this.attachedWebviewProviders.forEach((provider) => {
-            if (provider.webviewView?.webview !== webview) {
-              provider.sendStateUpdate(diff);
-            }
-          });
+          this._onDidUpdateState(webview, diff);
         }
       );
       return [attachDisposable, detatchDisposable, updateStateDisposable];
     });
     this.disposables.push(...disposables);
   }
+
+  /** When one webview updates state, broadcast that change to other webviews */
+  private _onDidUpdateState(
+    webview: vscode.Webview,
+    partialState: Record<string, any>
+  ) {
+    this.attachedWebviewProviders.forEach((provider) => {
+      if (provider.webviewView?.webview !== webview) {
+        provider.sendStateUpdate(partialState);
+      }
+    });
+  }
+
   private _onDidDetachWebview(webviewProvider: ReactWebViewProvider) {
     this.attachedWebviewProviders = this.attachedWebviewProviders.filter(
       (provider) => provider !== webviewProvider

--- a/vsc-extension/src/imaginary-message-router.ts
+++ b/vsc-extension/src/imaginary-message-router.ts
@@ -28,26 +28,37 @@ export class ImaginaryMessageRouter {
 
     const disposables = webviewProviders.flatMap((webviewProvider) => {
       const attachDisposable = webviewProvider.onDidAttachWebview((webview) => {
-        this.attachedWebviewProviders.push(webviewProvider);
-        this.disposables.push(
-          webview.onDidReceiveMessage((message) => {
-            this._onDidReceiveMessage.fire({
-              webviewProvider,
-              message,
-            });
-          })
-        );
+        this._onDidAttachWebview(webviewProvider, webview);
       });
       const detatchDisposable = webviewProvider.onDidDetatchWebview(() => {
         // TODO: dispose of attached onDidReceiveMessage disposable
-        this.attachedWebviewProviders = this.attachedWebviewProviders.filter(
-          (provider) => provider !== webviewProvider
-        );
+        this._onDidDetachWebview(webviewProvider);
       });
       return [attachDisposable, detatchDisposable];
     });
-    this.disposables.push(vscode.Disposable.from(...disposables));
+    this.disposables.push(...disposables);
   }
+  private _onDidDetachWebview(webviewProvider: ReactWebViewProvider) {
+    this.attachedWebviewProviders = this.attachedWebviewProviders.filter(
+      (provider) => provider !== webviewProvider
+    );
+  }
+
+  private _onDidAttachWebview(
+    webviewProvider: ReactWebViewProvider,
+    webview: vscode.Webview
+  ) {
+    this.attachedWebviewProviders.push(webviewProvider);
+    this.disposables.push(
+      webview.onDidReceiveMessage((message) => {
+        this._onDidReceiveMessage.fire({
+          webviewProvider,
+          message,
+        });
+      })
+    );
+  }
+
   dispose() {
     const d = vscode.Disposable.from(...this.disposables);
     d.dispose();

--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -6,9 +6,14 @@ import { ImaginaryMessage } from "../../src-shared/messages";
 export function registerWebView(
   extensionContext: vscode.ExtensionContext,
   viewName: string,
-  panelName: string
+  panelName: string,
+  state: Map<string, any>
 ) {
-  const webviewProvider = new ReactWebViewProvider(extensionContext, panelName);
+  const webviewProvider = new ReactWebViewProvider(
+    extensionContext,
+    panelName,
+    state
+  );
   extensionContext.subscriptions.push(
     vscode.window.registerWebviewViewProvider(viewName, webviewProvider)
   );
@@ -19,15 +24,27 @@ export function registerWebView(
 export class ReactWebViewProvider implements vscode.WebviewViewProvider {
   private _onDidAttachWebview = new vscode.EventEmitter<vscode.Webview>();
   private _onDidDetatchWebview = new vscode.EventEmitter<vscode.Webview>();
+  private _onDidUpdateState = new vscode.EventEmitter<{
+    webview: vscode.Webview;
+    diff: Record<string, any>;
+  }>();
   onDidAttachWebview = this._onDidAttachWebview.event;
   onDidDetatchWebview = this._onDidDetatchWebview.event;
+  onDidUpdateState = this._onDidUpdateState.event;
   viewId: string;
   extensionUri: vscode.Uri;
   webviewView?: vscode.WebviewView;
   rpcProvider: RpcProvider;
-  constructor(extensionContext: vscode.ExtensionContext, webviewId: string) {
+
+  localStateRef: Map<string, any>;
+  constructor(
+    extensionContext: vscode.ExtensionContext,
+    webviewId: string,
+    state: Map<string, any>
+  ) {
     this.viewId = webviewId;
     this.extensionUri = extensionContext.extensionUri;
+    this.localStateRef = state;
     this.rpcProvider = new RpcProvider((message, transfer) => {
       this.webviewView?.webview.postMessage({
         id: "rpc",
@@ -37,21 +54,34 @@ export class ReactWebViewProvider implements vscode.WebviewViewProvider {
     this.rpcProvider.registerRpcHandler(
       "read-state",
       async (itemKey: string) => {
-        // return state.get(itemKey)
+        console.log(`[extension ${this.viewId}] read-state`, itemKey);
+        return this.localStateRef.get(itemKey);
       }
     );
     this.rpcProvider.registerRpcHandler(
       "write-state",
       async (partialState: Record<string, unknown>) => {
+        console.log(`[extension ${this.viewId}] write-state`, partialState);
         Object.entries(partialState).forEach(([key, value]) => {
-          // return state.set(key, value)
+          this.localStateRef.set(key, value);
         });
+        if (this.webviewView) {
+          this._onDidUpdateState.fire({
+            webview: this.webviewView.webview,
+            diff: partialState,
+          });
+        }
       }
     );
   }
 
   rpc<T = void, U = void>(id: string, payload?: T, transfer?: any): Promise<U> {
     return this.rpcProvider.rpc(id, payload, transfer);
+  }
+
+  /** Broadcast out to the webview that some state has changed */
+  sendStateUpdate(newState: Record<string, any>) {
+    this.rpc("update-state", newState);
   }
 
   async resolveWebviewView(

--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -34,6 +34,20 @@ export class ReactWebViewProvider implements vscode.WebviewViewProvider {
         params: [message, transfer],
       });
     });
+    this.rpcProvider.registerRpcHandler(
+      "read-state",
+      async (itemKey: string) => {
+        // return state.get(itemKey)
+      }
+    );
+    this.rpcProvider.registerRpcHandler(
+      "write-state",
+      async (partialState: Record<string, unknown>) => {
+        Object.entries(partialState).forEach(([key, value]) => {
+          // return state.set(key, value)
+        });
+      }
+    );
   }
 
   rpc<T = void, U = void>(id: string, payload?: T, transfer?: any): Promise<U> {

--- a/vsc-extension/tsconfig.react.json
+++ b/vsc-extension/tsconfig.react.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- start wiring up recoil-sync using rpc provider
- minor cleanup of router
- initial POC for get/state state inside the webview provider
- wire up events to fire when a webview gets state updates
- when one webview gets a state update, broadcast the results to the other webviews
- better behavior for bootstrapping - use DefaultValue as appropriate
- now share extension state with views
- update target to let map iteration work
- proof-of-concept: share debugs tate
- store rpcProvider with setSTate, and do not render recoilsync until the RPC connection has been initialized
- set defaults globally
- add first shared state
