### PR TITLE
Clean up input editor a bit, and propagate selected test index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,6 +2394,10 @@
       "resolved": "transformers/babel",
       "link": true
     },
+    "node_modules/@imaginary-dev/imaginary-programming-extension": {
+      "resolved": "vsc-extension",
+      "link": true
+    },
     "node_modules/@imaginary-dev/nextjs-util": {
       "resolved": "nextjs-util",
       "link": true
@@ -7646,10 +7650,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/imaginary-programming": {
-      "resolved": "vsc-extension",
-      "link": true
     },
     "node_modules/immediate": {
       "version": "3.0.6",
@@ -13391,7 +13391,7 @@
       }
     },
     "vsc-extension": {
-      "name": "imaginary-programming",
+      "name": "@imaginary-dev/imaginary-programming-extension",
       "version": "0.0.1",
       "dependencies": {
         "@imaginary-dev/typescript-transformer": "*",

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -35,7 +35,7 @@
       "imaginary": [
         {
           "id": "imaginary.inputs",
-          "name": "Inputs here",
+          "name": "Test Inputs",
           "type": "webview"
         },
         {

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "imaginary-programming",
+  "name": "@imaginary-dev/imaginary-programming-extension",
   "displayName": "Imaginary Programming",
   "description": "",
   "version": "0.0.1",

--- a/vsc-extension/src-shared/source-info.ts
+++ b/vsc-extension/src-shared/source-info.ts
@@ -1,3 +1,4 @@
+import { ServiceParameters } from "@imaginary-dev/util";
 import * as ts from "typescript";
 
 export interface FunctionTestCase {
@@ -13,6 +14,8 @@ export interface FunctionTestCase {
     prev: any;
     current: any;
   };
+
+  serviceParameters?: ServiceParameters;
 }
 
 /** Wrapper for all test cases for a given function */
@@ -36,15 +39,17 @@ export interface SourceFileInfo {
 }
 export type SourceFileMap = Record<string, SourceFileInfo>;
 
+/** TODO: replace with JSONSchema */
+export interface ParameterDescriptor {
+  name: string;
+  /** Quick hack for POC of parameters */
+  tempType: "number" | "string" | "object" | "array" | string;
+}
+
 export interface SerializableFunctionDeclaration {
   name?: string;
   declaration: string;
-  parameters: {
-    name: string;
-
-    /** Quick hack for POC of parameters */
-    tempType: "number" | "string" | "object" | "array" | string;
-  }[];
+  parameters: ParameterDescriptor[];
 }
 
 interface SerializableSourceFile {

--- a/vsc-extension/src-views/components/InputPanel.tsx
+++ b/vsc-extension/src-views/components/InputPanel.tsx
@@ -2,7 +2,6 @@ import {
   VSCodeButton,
   VSCodeDropdown,
   VSCodeOption,
-  VSCodeTextArea,
 } from "@vscode/webview-ui-toolkit/react";
 import React, { useCallback, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -21,6 +20,7 @@ import {
   sourcesState,
   testCasesState,
 } from "../shared/state";
+import { TestCaseEditor } from "./TestCaseEditor";
 
 export const InputPanel = () => {
   const selectedFunction = useRecoilValue(selectedFunctionState);
@@ -107,29 +107,14 @@ export const InputPanel = () => {
         )}
         <VSCodeButton onClick={onAddTestCase}>Add test case</VSCodeButton>
       </div>
-      {!!selectedTestCase && (
-        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-          {selectedFunctionInfo?.parameters.map((param) => (
-            <div key={param.name} style={{ display: "flex" }}>
-              <VSCodeTextArea
-                style={{ flex: 1 }}
-                value={selectedTestCase.inputs[param.name] ?? ""}
-                onChange={(e: any) => {
-                  onUpdateTestCase(
-                    fileName,
-                    functionName,
-                    param.name,
-                    selectedTestCaseIndex,
-                    e.target.value
-                  );
-                }}
-              >
-                <code>{param.name}</code>
-              </VSCodeTextArea>
-            </div>
-          ))}
-        </div>
-      )}
+      {!!selectedTestCase &&
+        TestCaseEditor({
+          selectedFunctionInfo,
+          selectedTestCase,
+          onUpdateTestCase,
+          selectedFunction,
+          selectedTestCaseIndex,
+        })}
     </div>
   );
 };

--- a/vsc-extension/src-views/components/InputPanel.tsx
+++ b/vsc-extension/src-views/components/InputPanel.tsx
@@ -3,7 +3,7 @@ import {
   VSCodeDropdown,
   VSCodeOption,
 } from "@vscode/webview-ui-toolkit/react";
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import {
   FunctionTestCase,
@@ -17,6 +17,7 @@ import {
 import { findMatchingFunction } from "../../src/util/serialized-source";
 import {
   selectedFunctionState,
+  selectedTestCaseIndexState,
   sourcesState,
   testCasesState,
 } from "../shared/state";
@@ -26,7 +27,9 @@ export const InputPanel = () => {
   const selectedFunction = useRecoilValue(selectedFunctionState);
   const sources = useRecoilValue(sourcesState);
   const [testCases, setTestCases] = useRecoilState(testCasesState);
-  const [selectedTestCaseIndex, setSelectedTestCaseIndex] = useState(0);
+  const [selectedTestCaseIndex, setSelectedTestCaseIndex] = useRecoilState(
+    selectedTestCaseIndexState(selectedFunction)
+  );
 
   const onUpdateTestCase = useCallback(
     (
@@ -80,33 +83,31 @@ export const InputPanel = () => {
   }
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-      <p>
+      <div>
         Test cases for <code>{selectedFunction.functionName}</code>
-      </p>
-      {!functionTestCases && (
-        <p>
-          <i>No test cases yet</i>
-        </p>
-      )}
-      <div style={{ display: "flex" }}>
-        {!!functionTestCases && (
-          <VSCodeDropdown
-            onChange={(e) => {
-              const indexStr = (e.target as HTMLOptionElement).value;
-              const index = parseInt(indexStr);
-              setSelectedTestCaseIndex(index);
-            }}
-            value={`${selectedTestCaseIndex}`}
-          >
-            {functionTestCases.testCases.map((testCase, index) => (
-              <VSCodeOption key={index} value={`${index}`}>
-                {formatTestCase(selectedFunctionInfo, testCase)}
-              </VSCodeOption>
-            ))}
-          </VSCodeDropdown>
-        )}
-        <VSCodeButton onClick={onAddTestCase}>Add test case</VSCodeButton>
       </div>
+      {!functionTestCases && (
+        <div>
+          <i>No test cases yet</i>
+        </div>
+      )}
+      {!!functionTestCases && (
+        <VSCodeDropdown
+          onChange={(e) => {
+            const indexStr = (e.target as HTMLOptionElement).value;
+            const index = parseInt(indexStr);
+            setSelectedTestCaseIndex(index);
+          }}
+          value={`${selectedTestCaseIndex}`}
+        >
+          {functionTestCases.testCases.map((testCase, index) => (
+            <VSCodeOption key={index} value={`${index}`}>
+              {formatTestCase(selectedFunctionInfo, testCase)}
+            </VSCodeOption>
+          ))}
+        </VSCodeDropdown>
+      )}
+      <VSCodeButton onClick={onAddTestCase}>Add test case</VSCodeButton>
       {!!selectedTestCase &&
         TestCaseEditor({
           selectedFunctionInfo,

--- a/vsc-extension/src-views/components/OutputPanel.tsx
+++ b/vsc-extension/src-views/components/OutputPanel.tsx
@@ -10,6 +10,7 @@ import { findMatchingFunction } from "../../src/util/serialized-source";
 import {
   debugState,
   selectedFunctionState,
+  selectedTestCaseState,
   sourcesState,
   testCasesState,
 } from "../shared/state";
@@ -18,6 +19,7 @@ export function OutputPanel() {
   const sources = useRecoilValue(sourcesState);
   const testCases = useRecoilValue(testCasesState);
   const selectedFunction = useRecoilValue(selectedFunctionState);
+  const selectedTestCaseIndexes = useRecoilValue(selectedTestCaseState);
 
   const fn = findMatchingFunction(sources, selectedFunction);
   const [debug, setDebug] = useRecoilState(debugState);
@@ -58,6 +60,8 @@ export function OutputPanel() {
           <pre>{JSON.stringify(selectedFunction, null, 4)}</pre>
           <p>Inputs/Outputs</p>
           <pre>{JSON.stringify(testCases, null, 4)}</pre>
+          <p>TestCaseIndexes</p>
+          <pre>{JSON.stringify(selectedTestCaseIndexes, null, 4)}</pre>
         </div>
       )}
     </>

--- a/vsc-extension/src-views/components/ParameterValueEditor.tsx
+++ b/vsc-extension/src-views/components/ParameterValueEditor.tsx
@@ -32,19 +32,30 @@ export const ParameterValueEditor: FC<Props> = ({
   return (
     <div key={param.name} style={{ display: "flex" }}>
       <VSCodeTextArea
-        style={{ flex: 1 }}
+        style={{ flex: 1, width: "100%" }}
         value={selectedTestCase.inputs[param.name] ?? ""}
-        onChange={(e) => {
+        onChange={(e: any) => {
           onUpdateTestCase(
             fileName,
             functionName,
             param.name,
             selectedTestCaseIndex,
-            e.target.value
+            e.target?.value
           );
         }}
       >
-        <code>{param.name}</code>
+        <div style={{ display: "flex" }}>
+          <code
+            style={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              gap: "1rem",
+            }}
+          >
+            {param.name}
+          </code>
+          <span>({param.tempType})</span>
+        </div>
       </VSCodeTextArea>
     </div>
   );

--- a/vsc-extension/src-views/components/ParameterValueEditor.tsx
+++ b/vsc-extension/src-views/components/ParameterValueEditor.tsx
@@ -1,0 +1,51 @@
+import { VSCodeTextArea } from "@vscode/webview-ui-toolkit/react";
+import React, { FC } from "react";
+import {
+  FunctionTestCase,
+  ParameterDescriptor,
+  SelectedFunction,
+} from "../../src-shared/source-info";
+
+interface Props {
+  param: ParameterDescriptor;
+  selectedTestCase: FunctionTestCase;
+  onUpdateTestCase: (
+    sourceFileName: string,
+    functionName: string,
+    paramName: string,
+    testCaseIndex: number,
+    value: string
+  ) => void;
+
+  selectedFunction: SelectedFunction;
+  selectedTestCaseIndex: number;
+}
+
+export const ParameterValueEditor: FC<Props> = ({
+  param,
+  selectedTestCase,
+  onUpdateTestCase,
+  selectedFunction,
+  selectedTestCaseIndex,
+}) => {
+  const { fileName, functionName } = selectedFunction;
+  return (
+    <div key={param.name} style={{ display: "flex" }}>
+      <VSCodeTextArea
+        style={{ flex: 1 }}
+        value={selectedTestCase.inputs[param.name] ?? ""}
+        onChange={(e) => {
+          onUpdateTestCase(
+            fileName,
+            functionName,
+            param.name,
+            selectedTestCaseIndex,
+            e.target.value
+          );
+        }}
+      >
+        <code>{param.name}</code>
+      </VSCodeTextArea>
+    </div>
+  );
+};

--- a/vsc-extension/src-views/components/TestCaseEditor.tsx
+++ b/vsc-extension/src-views/components/TestCaseEditor.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from "react";
+import {
+  FunctionTestCase,
+  SelectedFunction,
+  SerializableFunctionDeclaration,
+} from "../../src-shared/source-info";
+import { ParameterValueEditor } from "./ParameterValueEditor";
+
+interface Props {
+  selectedFunctionInfo: SerializableFunctionDeclaration | undefined;
+  selectedTestCase: FunctionTestCase;
+  onUpdateTestCase: (
+    sourceFileName: string,
+    functionName: string,
+    paramName: string,
+    testCaseIndex: number,
+    value: string
+  ) => void;
+  selectedFunction: SelectedFunction;
+  selectedTestCaseIndex: number;
+}
+
+export const TestCaseEditor: FC<Props> = ({
+  selectedFunctionInfo,
+  selectedTestCase,
+  onUpdateTestCase,
+  selectedFunction,
+  selectedTestCaseIndex,
+}) => {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      {selectedFunctionInfo?.parameters.map((param) => (
+        <ParameterValueEditor
+          key={param.name}
+          param={param}
+          selectedTestCase={selectedTestCase}
+          onUpdateTestCase={onUpdateTestCase}
+          selectedFunction={selectedFunction}
+          selectedTestCaseIndex={selectedTestCaseIndex}
+        />
+      ))}
+      <TemperatureEditor />
+    </div>
+  );
+};
+
+const TemperatureEditor: FC = () => {
+  return (
+    <div>
+      <p>Temperature</p>
+      <p>(temperature editor here)</p>
+    </div>
+  );
+};

--- a/vsc-extension/src-views/shared/state.ts
+++ b/vsc-extension/src-views/shared/state.ts
@@ -1,8 +1,9 @@
 import { Checker, custom, nullable } from "@recoiljs/refine";
-import { atom, DefaultValue } from "recoil";
+import { atom, DefaultValue, selectorFamily } from "recoil";
 import { syncEffect } from "recoil-sync";
 import {
   MaybeSelectedFunction,
+  SelectedFileTestCases,
   SerializableSourceFileMap,
   SourceFileTestCaseMap,
 } from "../../src-shared/source-info";
@@ -38,4 +39,43 @@ export const sourcesState = atom<SerializableSourceFileMap>({
   default: {},
   key: "sources",
   effects: [synced({})],
+});
+
+export const selectedTestCaseState = atom<SelectedFileTestCases>({
+  default: {},
+  key: "selectedTestCases",
+  effects: [synced({})],
+});
+
+export const selectedTestCaseIndexState = selectorFamily({
+  key: "yyy",
+  get:
+    (params: { functionName: string; fileName: string } | null) =>
+    ({ get }) => {
+      if (!params) {
+        return 0;
+      }
+      const { fileName, functionName } = params;
+      const stcs = get(selectedTestCaseState);
+      return stcs[functionName]?.[fileName]?.testCaseIndex ?? 0;
+    },
+  set:
+    (params: { functionName: string; fileName: string } | null) =>
+    ({ set }, value) => {
+      if (!params) {
+        return;
+      }
+      const newValue = value instanceof DefaultValue ? 0 : value;
+      const { fileName, functionName } = params;
+      set(selectedTestCaseState, (prevValue) => {
+        const v: SelectedFileTestCases = {
+          ...prevValue,
+          [fileName]: {
+            ...prevValue[fileName],
+            [functionName]: { testCaseIndex: newValue },
+          },
+        };
+        return v;
+      });
+    },
 });

--- a/vsc-extension/src-views/shared/state.ts
+++ b/vsc-extension/src-views/shared/state.ts
@@ -47,6 +47,13 @@ export const selectedTestCaseState = atom<SelectedFileTestCases>({
   effects: [synced({})],
 });
 
+/** This is a kind of helper selector that lets you just update the selected index for a given state, e.g.
+ *
+ * ```
+ * const selectedFunction = useRecoilValue(selectedFunctionState);
+ * const [testIndex, setTestIndex] = useRecoilState(selectedTestCaseIndexState(selectedFunction));
+ * ```
+ */
 export const selectedTestCaseIndexState = selectorFamily({
   key: "yyy",
   get:

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -19,6 +19,7 @@ const initialState: State = {
   selectedFunction: null,
   sources: {},
   testCases: {},
+  selectedTestCases: {},
 };
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed

--- a/vsc-extension/src/util/state.ts
+++ b/vsc-extension/src/util/state.ts
@@ -6,9 +6,31 @@ import {
 } from "../../src-shared/source-info";
 
 export interface State {
+  /** Contains all imaginary functions in the form
+   * fileName -> functionName -> SerializableFunctionDeclaration
+   */
   sources: SerializableSourceFileMap;
+  /**
+   * Contains the currently "selected" function - meaning the cursor is over the
+   * function and/or the user has selected it via other affordances
+   */
   selectedFunction: MaybeSelectedFunction;
+
+  /** Internal debug flag */
   "app.debugMode": boolean;
+
+  /** Contains the test cases for a function, in the form
+   *
+   * fileName -> functionName -> FunctionTestCase[]
+   */
   testCases: SourceFileTestCaseMap;
+
+  /**
+   * Records the index of the "selected" test case for a given function in the form.
+   *
+   * fileName -> functionName -> { selectedIndex: 1 }
+   *
+   * This allows each fileName/functionName combination to have its own selected state.
+   */
   selectedTestCases: SelectedFunctionTestCases;
 }

--- a/vsc-extension/src/util/state.ts
+++ b/vsc-extension/src/util/state.ts
@@ -1,5 +1,6 @@
 import {
   MaybeSelectedFunction,
+  SelectedFunctionTestCases,
   SerializableSourceFileMap,
   SourceFileTestCaseMap,
 } from "../../src-shared/source-info";
@@ -9,4 +10,5 @@ export interface State {
   selectedFunction: MaybeSelectedFunction;
   "app.debugMode": boolean;
   testCases: SourceFileTestCaseMap;
+  selectedTestCases: SelectedFunctionTestCases;
 }


### PR DESCRIPTION
- remove debug state
- move shared components to components dir
- break out serialize code
- testcase manipulation broken out of inputpanel
- make jest work
- tests for test case manipulation
- oops, build errors
- bring in tests to main build
- better name for vscode package
- break out some individual components
- better title for panel
- add selectedTestCases to state
- propagate selectedTestCases
