### PR TITLE
Wire up basic "run" button in the righthand panel (temporarily)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13351,6 +13351,7 @@
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "html-template-tag": "^4.0.1",
         "immer": "^9.0.21",
+        "openai": "^3.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recoil": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -228,6 +229,7 @@
       "version": "7.21.4",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.4.tgz",
       "integrity": "sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -236,6 +238,7 @@
       "version": "7.21.4",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.4.tgz",
       "integrity": "sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.21.4",
@@ -264,7 +267,8 @@
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/@babel/generator": {
       "version": "7.21.4",
@@ -308,6 +312,7 @@
       "version": "7.21.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.4.tgz",
       "integrity": "sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.21.4",
         "@babel/helper-validator-option": "^7.21.0",
@@ -400,6 +405,7 @@
       "version": "7.21.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
       "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -453,6 +459,7 @@
       "version": "7.20.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
       "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.2"
       },
@@ -502,6 +509,7 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
       "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -510,6 +518,7 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
       "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.21.0",
@@ -2229,6 +2238,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -2243,6 +2253,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
       "integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+      "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -2251,6 +2262,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
       "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+      "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -2273,6 +2285,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2287,12 +2300,14 @@
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
       "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2307,6 +2322,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2317,12 +2333,14 @@
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2334,6 +2352,7 @@
       "version": "8.37.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
       "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -2342,6 +2361,7 @@
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
       "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -2355,6 +2375,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2366,7 +2387,8 @@
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "node_modules/@imaginary-dev/babel-transformer": {
       "resolved": "transformers/babel",
@@ -2719,6 +2741,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -4364,6 +4387,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -4461,6 +4485,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5597,7 +5622,8 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.0",
@@ -5698,6 +5724,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -6029,6 +6056,7 @@
       "version": "8.37.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
       "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
+      "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -6397,6 +6425,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -6420,6 +6449,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6434,12 +6464,14 @@
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6451,6 +6483,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -6466,6 +6499,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -6477,6 +6511,7 @@
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
       "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -6491,6 +6526,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6501,12 +6537,14 @@
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -6521,6 +6559,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -6535,6 +6574,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6546,6 +6586,7 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
       "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -6575,6 +6616,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
       "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -6713,7 +6755,8 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -6765,6 +6808,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -6831,6 +6875,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
       "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -6842,7 +6887,8 @@
     "node_modules/flatted": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
     },
     "node_modules/focus-lock": {
       "version": "0.11.6",
@@ -7035,6 +7081,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -7265,7 +7312,8 @@
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "node_modules/hamt_plus": {
       "version": "1.0.2",
@@ -7664,6 +7712,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -7977,6 +8026,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8925,6 +8975,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
       "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -9055,6 +9106,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "node_modules/json-schema-diff": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/json-schema-diff/-/json-schema-diff-0.18.0.tgz",
@@ -9103,7 +9159,8 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -9238,6 +9295,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -9314,7 +9372,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -9336,6 +9395,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -9526,7 +9586,8 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
@@ -10085,6 +10146,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -10101,6 +10163,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -10219,6 +10282,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10466,6 +10530,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -11057,6 +11122,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11071,6 +11137,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -11478,6 +11545,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -11507,6 +11575,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -12013,7 +12082,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -12381,6 +12451,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -13083,6 +13154,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13178,7 +13250,8 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -13242,6 +13315,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13346,11 +13420,13 @@
       "name": "@imaginary-dev/imaginary-programming-extension",
       "version": "0.0.1",
       "dependencies": {
+        "@imaginary-dev/runtime": "*",
         "@imaginary-dev/typescript-transformer": "*",
         "@imaginary-dev/util": "*",
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "html-template-tag": "^4.0.1",
         "immer": "^9.0.21",
+        "json-schema": "^0.4.0",
         "openai": "^3.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/prompt-engine/src/prompt-openai-chat.test.ts
+++ b/prompt-engine/src/prompt-openai-chat.test.ts
@@ -1,4 +1,7 @@
-import { ServiceParameters } from "@imaginary-dev/util";
+import {
+  getSafeOpenAIServiceParameters,
+  ServiceParameters,
+} from "@imaginary-dev/util";
 import { Configuration, CreateChatCompletionRequest, OpenAIApi } from "openai";
 import { Prompt } from "./prompt";
 import {
@@ -65,7 +68,7 @@ describe("runPrompt", () => {
       ],
       temperature: serviceParameters.openai?.temperature ?? DEFAULT_TEMPERATURE,
       max_tokens: serviceParameters.openai?.max_tokens ?? DEFAULT_MAX_TOKENS,
-      ...serviceParameters.openai,
+      ...getSafeOpenAIServiceParameters(serviceParameters),
     };
 
     const response = {

--- a/prompt-engine/src/prompt-openai-chat.ts
+++ b/prompt-engine/src/prompt-openai-chat.ts
@@ -1,5 +1,6 @@
 import { ServiceParameters } from "@imaginary-dev/util";
 import { Configuration, CreateChatCompletionRequest, OpenAIApi } from "openai";
+import { getSafeOpenAIServiceParameters } from "util/dist/util/src";
 import { Prompt, replaceVariablesInPrompt } from "./prompt";
 import {
   getHttpErrorMessage,
@@ -70,7 +71,7 @@ export const runPrompt: (
     temperature: serviceParameters?.openai?.temperature ?? DEFAULT_TEMPERATURE,
     max_tokens:
       serviceParameters?.openai?.max_tokens ?? getMaxTokensForModel(model),
-    ...serviceParameters.openai,
+    ...getSafeOpenAIServiceParameters(serviceParameters),
   };
   if (process.env.PROMPTJS_LOGGING_ENABLED) {
     console.log("requesting messages: ", completionRequest.messages);

--- a/prompt-engine/src/prompt-openai-chat.ts
+++ b/prompt-engine/src/prompt-openai-chat.ts
@@ -1,6 +1,8 @@
-import { ServiceParameters } from "@imaginary-dev/util";
+import {
+  getSafeOpenAIServiceParameters,
+  ServiceParameters,
+} from "@imaginary-dev/util";
 import { Configuration, CreateChatCompletionRequest, OpenAIApi } from "openai";
-import { getSafeOpenAIServiceParameters } from "util/dist/util/src";
 import { Prompt, replaceVariablesInPrompt } from "./prompt";
 import {
   getHttpErrorMessage,
@@ -29,17 +31,19 @@ export const runPrompt: (
   serviceParameters,
   openaiApi
 ) => {
-  if (!process.env.OPENAI_API_KEY) {
+  const apiKey =
+    serviceParameters.openai?.apiConfig?.apiKey ?? process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     throw new Error(
       "Missing OPENAI_API_KEY environment variable. See https://www.imaginary.dev/docs/installing-with-babel#adding-your-open-ai-api-key for details."
     );
   }
   const configuration = new Configuration({
-    apiKey: process.env.OPENAI_API_KEY,
+    apiKey,
   });
-  if (process.env.OPENAI_API_KEY) {
+  if (apiKey) {
     configuration["headers"] = {
-      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      Authorization: `Bearer ${apiKey}`,
     };
   }
 

--- a/prompt-engine/src/prompt-openai-completion.ts
+++ b/prompt-engine/src/prompt-openai-completion.ts
@@ -1,4 +1,7 @@
-import { ServiceParameters } from "@imaginary-dev/util";
+import {
+  getSafeOpenAIServiceParameters,
+  ServiceParameters,
+} from "@imaginary-dev/util";
 import { Configuration, CreateCompletionRequest, OpenAIApi } from "openai";
 import { Prompt, replaceVariablesInPrompt } from "./prompt";
 import {
@@ -53,7 +56,7 @@ const runPrompt: (
     suffix: promptParts.suffix,
     max_tokens: serviceParameters?.openai?.max_tokens ?? DEFAULT_MAX_TOKENS,
     temperature: serviceParameters?.openai?.temperature ?? DEFAULT_TEMPERATURE,
-    ...serviceParameters.openai,
+    ...getSafeOpenAIServiceParameters(serviceParameters),
   };
   if (process.env.PROMPTJS_LOGGING_ENABLED) {
     console.log("requesting prompt: ", completionRequest.prompt);

--- a/prompt-engine/src/prompt-openai-completion.ts
+++ b/prompt-engine/src/prompt-openai-completion.ts
@@ -28,17 +28,19 @@ const runPrompt: (
   parameters,
   serviceParameters
 ) => {
-  if (!process.env.OPENAI_API_KEY) {
+  const apiKey =
+    serviceParameters.openai?.apiConfig?.apiKey ?? process.env.OPENAI_API_KEY;
+  if (!apiKey) {
     throw new Error(
       "Missing OPENAI_API_KEY environment variable. See https://www.imaginary.dev/docs/installing-with-babel#adding-your-open-ai-api-key for details."
     );
   }
   const configuration = new Configuration({
-    apiKey: process.env.OPENAI_API_KEY,
+    apiKey,
   });
-  if (process.env.OPENAI_API_KEY) {
+  if (apiKey) {
     configuration["headers"] = {
-      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      Authorization: `Bearer ${apiKey}`,
     };
   }
 

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -67,6 +67,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "html-template-tag": "^4.0.1",
     "immer": "^9.0.21",
+    "openai": "^3.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recoil": "^0.7.7",

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -64,9 +64,11 @@
   "dependencies": {
     "@imaginary-dev/typescript-transformer": "*",
     "@imaginary-dev/util": "*",
+    "@imaginary-dev/runtime": "*",
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "html-template-tag": "^4.0.1",
     "immer": "^9.0.21",
+    "json-schema": "^0.4.0",
     "openai": "^3.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/vsc-extension/src-views/components/InputPanel.tsx
+++ b/vsc-extension/src-views/components/InputPanel.tsx
@@ -1,4 +1,3 @@
-import { provideVSCodeDesignSystem } from "@vscode/webview-ui-toolkit";
 import {
   VSCodeButton,
   VSCodeDropdown,
@@ -11,11 +10,7 @@ import {
   FunctionTestCase,
   SerializableFunctionDeclaration,
 } from "../../src-shared/source-info";
-import {
-  addFunctionTestCase,
-  findTestCases,
-  updateSourcefileTestCase,
-} from "../../src-shared/testcases";
+import { addFunctionTestCase, findTestCases } from "../../src-shared/testcases";
 import {
   selectedFunctionState,
   selectedTestCaseIndexState,

--- a/vsc-extension/src-views/components/RecoilSyncWebview.tsx
+++ b/vsc-extension/src-views/components/RecoilSyncWebview.tsx
@@ -37,7 +37,7 @@ function useRpc(rpcProvider: RpcProvider | undefined): {
     }
     const reader: ReadItem = async (itemKey) => {
       console.log(`[webview ${!!rpcProvider}] reading key: `, itemKey);
-      const value = rpcProvider?.rpc("read-state", itemKey);
+      const value = rpcProvider.rpc("read-state", itemKey);
       if (value === undefined) {
         return new DefaultValue();
       }
@@ -47,7 +47,7 @@ function useRpc(rpcProvider: RpcProvider | undefined): {
       console.log("[webview] writing items: ", diff.keys());
       const entries = [...diff];
       const values = Object.fromEntries(entries);
-      return rpcProvider?.rpc("write-state", values);
+      return rpcProvider.rpc("write-state", values);
     };
 
     // Note there is no unregister here

--- a/vsc-extension/src-views/components/TestCaseEditor.tsx
+++ b/vsc-extension/src-views/components/TestCaseEditor.tsx
@@ -1,9 +1,11 @@
-import React, { FC } from "react";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import React, { FC, useCallback } from "react";
 import {
   FunctionTestCase,
   SelectedFunction,
   SerializableFunctionDeclaration,
 } from "../../src-shared/source-info";
+import { useExtensionState } from "./ExtensionState";
 import { ParameterValueEditor } from "./ParameterValueEditor";
 
 interface Props {
@@ -34,6 +36,10 @@ export const TestCaseEditor: FC<Props> = ({
         />
       ))}
       <TemperatureEditor />
+      <RunButton
+        selectedFunction={selectedFunction}
+        testCaseIndex={selectedTestCaseIndex}
+      />
     </div>
   );
 };
@@ -45,4 +51,29 @@ const TemperatureEditor: FC = () => {
       <p>(temperature editor here)</p>
     </div>
   );
+};
+
+const RunButton: FC<{
+  selectedFunction: SelectedFunction;
+  testCaseIndex: number;
+}> = ({ selectedFunction, testCaseIndex }) => {
+  const { rpcProvider } = useExtensionState();
+  const { fileName, functionName } = selectedFunction;
+
+  const onRun = useCallback(async () => {
+    try {
+      await rpcProvider?.rpc("runTestCase", {
+        fileName,
+        functionName,
+        testCaseIndex,
+      });
+    } catch (ex) {
+      console.error(`Failure to run: ${ex}`, ex);
+    }
+  }, [fileName, functionName, rpcProvider, testCaseIndex]);
+
+  if (!rpcProvider) {
+    return null;
+  }
+  return <VSCodeButton onClick={onRun}>Run</VSCodeButton>;
 };

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -1,0 +1,120 @@
+import { callImaginaryFunction } from "@imaginary-dev/runtime";
+import { getImaginaryTsDocComments } from "@imaginary-dev/typescript-transformer";
+import { JSONSchema7 } from "json-schema";
+import ts from "typescript";
+import * as vscode from "vscode";
+import { findTestCases } from "../src-shared/testcases";
+import { ExtensionHostState } from "./util/extension-state";
+import { SecretInfo, SecretsProxy } from "./util/secrets";
+import { findNativeFunction } from "./util/source";
+import { State } from "./util/state";
+import { TypedMap } from "./util/types";
+
+const globalSecretInfo: SecretInfo[] = [
+  {
+    key: "openaiApiKey",
+    prompt: "Enter your OpenAI API Key",
+  },
+];
+
+export function makeRpcHandlers(
+  extensionContext: vscode.ExtensionContext,
+  state: TypedMap<State>,
+  extensionLocalState: TypedMap<ExtensionHostState>
+) {
+  const secretsProxy = new SecretsProxy(extensionContext, globalSecretInfo);
+
+  return {
+    async runTestCase({
+      fileName,
+      functionName,
+      testCaseIndex,
+    }: {
+      fileName: string;
+      functionName: string;
+      testCaseIndex: number;
+    }) {
+      console.log(
+        "[Extension Host] ",
+        `runTestCase: ${fileName}, ${functionName}, ${testCaseIndex}`
+      );
+      const testCases = findTestCases(
+        state.get("testCases"),
+        fileName,
+        functionName
+      );
+      if (!testCases || testCaseIndex >= testCases.testCases.length) {
+        console.error("failure 1", testCases, " from ", fileName, functionName);
+        throw new Error(
+          `Trying to run test case #${testCaseIndex} with ${
+            testCases?.testCases.length ?? 0
+          } test cases`
+        );
+      }
+      const testCase = testCases.testCases[testCaseIndex];
+      const functionInfo = findNativeFunction(
+        extensionLocalState.get("nativeSources"),
+        fileName,
+        functionName
+      );
+      if (!functionInfo) {
+        console.error(
+          "failure 2",
+          `Unable to find function declaration for ${functionName} in ${fileName}`
+        );
+        throw new Error(
+          `Unable to find function declaration for ${functionName} in ${fileName}`
+        );
+      }
+      const { fn, sourceFile } = functionInfo;
+      console.log("getting comments from ", fn, sourceFile);
+      const funcComment = getImaginaryTsDocComments(fn, sourceFile)[0];
+
+      console.log("getting api key");
+      const apiKey = await secretsProxy.getSecret("openaiApiKey");
+
+      console.log("getting params from ", fn);
+      const parameterTypes = hackyGetParamTypes(fn, sourceFile);
+
+      // super hack while developing
+      const returnSchema: JSONSchema7 = { type: "string" };
+      const paramValues = Object.fromEntries(
+        parameterTypes.map(({ name }) => [name, testCase.inputs[name]])
+      );
+      console.log("about to run...");
+      try {
+        const result = await callImaginaryFunction(
+          funcComment,
+          functionName,
+          parameterTypes,
+          returnSchema,
+          paramValues,
+          { openai: { apiConfig: { apiKey } } }
+        );
+        console.log("got result: ", typeof result, ": ", result);
+        return result;
+      } catch (ex) {
+        console.error("Got error: ", ex);
+        throw ex;
+      }
+    },
+  };
+}
+/** This just gets all the types as `any`, since we do not have a ts.TypeChecker available */
+function hackyGetParamTypes(
+  fn: ts.FunctionDeclaration,
+  sourceFile: ts.SourceFile
+) {
+  const params = fn.parameters
+    .map((param) => param.name)
+    .filter((param): param is ts.Identifier => {
+      if (!ts.isIdentifier(param)) {
+        console.error("failure 3", param);
+
+        throw new Error(`Parameter ${param} must be a named parameter`);
+      }
+      return true;
+    })
+    .map((paramName) => ({ name: paramName.getText(sourceFile) }));
+  return params;
+}

--- a/vsc-extension/src/util/extension-state.ts
+++ b/vsc-extension/src/util/extension-state.ts
@@ -1,0 +1,9 @@
+import { SourceFileMap } from "./ts-source";
+
+/**
+ * This is state that stays within the extension host, and is not visible to
+ * webviews */
+export interface ExtensionHostState {
+  /** The master map of all parsed imaginary functions */
+  nativeSources: SourceFileMap;
+}

--- a/vsc-extension/src/util/secrets.ts
+++ b/vsc-extension/src/util/secrets.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode";
+
+export interface SecretInfo {
+  key: string;
+  prompt: string;
+}
+export class SecretsProxy {
+  context: vscode.ExtensionContext;
+  secretInfos: SecretInfo[];
+
+  constructor(context: vscode.ExtensionContext, secretInfos: SecretInfo[]) {
+    this.context = context;
+    this.secretInfos = secretInfos;
+  }
+  async getSecret(secretKey: string): Promise<string | undefined> {
+    const secret = await this.context.secrets.get(secretKey);
+    if (secret === undefined) {
+      const value = await this.requestSecret(secretKey);
+      return value;
+    }
+    return secret;
+  }
+
+  /** Prompt user for a secret and store the result */
+  async requestSecret(secretKey: string) {
+    const secretInfo = this.secretInfos.find(({ key }) => key === secretKey);
+    const value = await vscode.window.showInputBox({
+      prompt: secretInfo?.prompt ?? `Enter a value for "${secretKey}"`,
+    });
+
+    if (value) {
+      this.context.secrets.store(secretKey, value);
+    }
+    return value;
+  }
+}

--- a/vsc-extension/src/util/source.ts
+++ b/vsc-extension/src/util/source.ts
@@ -54,3 +54,21 @@ export function updateFile(
     },
   };
 }
+
+export function findNativeFunction(
+  sources: Readonly<SourceFileMap>,
+  fileName: string,
+  functionName: string
+) {
+  const functionSource = sources[fileName];
+  if (!functionSource) {
+    return;
+  }
+  const fn = functionSource.functions.find(
+    (fnDecl) => fnDecl.name?.getText(functionSource.sourceFile) === functionName
+  );
+  if (!fn) {
+    return;
+  }
+  return { fn, sourceFile: functionSource.sourceFile };
+}


### PR DESCRIPTION
- install openai
- rpcProvider is guaranteed
- leftover from refactoring
- only let whitelisted openai params through
- allow apiKey to be passed in via parameters
- wire up run button to call RPC directly
- add SecretsProxy to lazily prompt user for api key
- convert nativeSources to a mutable map, so we can have an updated version from rpc handlers
- add rpc handler for running a function
- add findNativeFunction for finding a function by name
- bring in dependencies
