### PR TITLE
Automatically add a test name when it hasn't been set before

### DIFF
--- a/vsc-extension/src-shared/source-info.ts
+++ b/vsc-extension/src-shared/source-info.ts
@@ -3,6 +3,8 @@ import { ServiceParameters } from "@imaginary-dev/util";
 export interface FunctionTestCase {
   /** Map of parameter name => value */
   name: string;
+  /** Set if the user manually sets the name */
+  hasCustomName?: boolean;
   inputs: Record<string, any>;
   /**
    * The outputs from running the function with these inputs

--- a/vsc-extension/src-shared/testcases.test.ts
+++ b/vsc-extension/src-shared/testcases.test.ts
@@ -2,7 +2,7 @@ import { FunctionTestCase, SourceFileTestCaseMap } from "./source-info";
 import {
   addFunctionTestCase,
   findTestCases,
-  updateSourcefileTestCaseInput,
+  updateSourceFileTestCase,
 } from "./testcases";
 
 describe("addFunctionTestCase", () => {
@@ -189,13 +189,20 @@ describe("updateSourcefileTestCase", () => {
     const index = 0;
     const paramName = "a";
     const value = 3;
-    const result = updateSourcefileTestCaseInput(
+    const result = updateSourceFileTestCase(
       sourceFileTestCases,
       sourceFileName,
       functionName,
       index,
-      paramName,
-      value
+      (prevTestCase) => ({
+        name: "New test case",
+        output: { prev: null, current: null },
+        ...prevTestCase,
+        inputs: {
+          ...prevTestCase?.inputs,
+          [paramName]: value,
+        },
+      })
     );
 
     expect(result).toEqual({
@@ -229,13 +236,22 @@ describe("updateSourcefileTestCase", () => {
     const index = 0;
     const paramName = "a";
     const value = 1;
-    const result = updateSourcefileTestCaseInput(
+    const result = updateSourceFileTestCase(
       sourceFileTestCases,
       sourceFileName,
       functionName,
       index,
-      paramName,
-      value
+      (prevTestCase) => {
+        return {
+          name: "New test case",
+          output: { prev: null, current: null },
+          ...prevTestCase,
+          inputs: {
+            ...prevTestCase?.inputs,
+            [paramName]: value,
+          },
+        };
+      }
     );
 
     expect(result).toEqual({
@@ -280,13 +296,19 @@ describe("updateSourcefileTestCase", () => {
     const index = 1;
     const paramName = "a";
     const value = 3;
-    const result = updateSourcefileTestCaseInput(
+    const result = updateSourceFileTestCase(
       sourceFileTestCases,
       sourceFileName,
       functionName,
       index,
-      paramName,
-      value
+      (prevTestCase) => ({
+        name: "New test case",
+        output: { prev: null, current: null },
+        ...prevTestCase,
+        inputs: {
+          [paramName]: value,
+        },
+      })
     );
 
     expect(result).toEqual({

--- a/vsc-extension/src-shared/testcases.test.ts
+++ b/vsc-extension/src-shared/testcases.test.ts
@@ -1,6 +1,7 @@
 import { FunctionTestCase, SourceFileTestCaseMap } from "./source-info";
 import {
   addFunctionTestCase,
+  blankTestCase,
   findTestCases,
   updateSourceFileTestCase,
 } from "./testcases";
@@ -195,8 +196,7 @@ describe("updateSourcefileTestCase", () => {
       functionName,
       index,
       (prevTestCase) => ({
-        name: "New test case",
-        output: { prev: null, current: null },
+        ...blankTestCase,
         ...prevTestCase,
         inputs: {
           ...prevTestCase?.inputs,
@@ -243,8 +243,7 @@ describe("updateSourcefileTestCase", () => {
       index,
       (prevTestCase) => {
         return {
-          name: "New test case",
-          output: { prev: null, current: null },
+          ...blankTestCase,
           ...prevTestCase,
           inputs: {
             ...prevTestCase?.inputs,
@@ -262,7 +261,7 @@ describe("updateSourcefileTestCase", () => {
             functionName: "newFunction",
             testCases: [
               {
-                name: "New test case",
+                name: "New test",
                 inputs: { a: 1 },
                 output: { prev: null, current: null },
               },
@@ -302,8 +301,7 @@ describe("updateSourcefileTestCase", () => {
       functionName,
       index,
       (prevTestCase) => ({
-        name: "New test case",
-        output: { prev: null, current: null },
+        ...blankTestCase,
         ...prevTestCase,
         inputs: {
           [paramName]: value,
@@ -324,7 +322,7 @@ describe("updateSourcefileTestCase", () => {
                 output: { prev: null, current: null },
               },
               {
-                name: "New test case",
+                name: "New test",
                 inputs: { a: 3 },
                 output: { prev: null, current: null },
               },

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -1,3 +1,4 @@
+import { produce } from "immer";
 import {
   FunctionTestCase,
   FunctionTestCases,
@@ -72,7 +73,22 @@ export function findTestCases(
   );
 }
 
-import { produce } from "immer";
+export function findTestCase(
+  testCases: SourceFileTestCaseMap,
+  fileName: string,
+  functionName: string,
+  testCaseIndex: number
+) {
+  const functionTestCases = findTestCases(testCases, fileName, functionName);
+  if (
+    !functionTestCases ||
+    testCaseIndex >= functionTestCases.testCases.length
+  ) {
+    return null;
+  }
+  const testCase = functionTestCases.testCases[testCaseIndex];
+  return testCase;
+}
 
 const emptyTestCase: FunctionTestCase = {
   inputs: {},

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -5,6 +5,15 @@ import {
   SourceFileTestCaseMap,
 } from "./source-info";
 
+export const blankTestCase: FunctionTestCase = {
+  name: "New test",
+  inputs: {},
+  output: {
+    prev: null,
+    current: null,
+  },
+};
+
 export function addFunctionTestCase(
   testCases: SourceFileTestCaseMap,
   sourceFileName: string,

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -90,145 +90,10 @@ export function findTestCase(
   return testCase;
 }
 
-const emptyTestCase: FunctionTestCase = {
-  inputs: {},
-  name: "New test case",
-  output: {
-    current: null,
-    prev: null,
-  },
-};
-
-function updateFunctionTestCaseInput<T>(
-  functionTestCase: FunctionTestCase,
-  paramName: string,
-  value: T
-): FunctionTestCase {
-  return produce(functionTestCase, (draft) => {
-    draft.inputs[paramName] = value;
-  });
-}
-
-function updateFunctionTestCasesInput<T>(
-  functionTestCases: FunctionTestCases,
-  index: number,
-  paramName: string,
-  value: T
-): FunctionTestCases {
-  return produce(functionTestCases, (draft) => {
-    draft.testCases = produce(draft.testCases, (draftTestCases) => {
-      draftTestCases[index] = updateFunctionTestCaseInput(
-        draftTestCases[index] ?? emptyTestCase,
-        paramName,
-        value
-      );
-    });
-  });
-}
-
-export function updateSourcefileTestCaseInput<T>(
-  sourceFileTestCases: SourceFileTestCaseMap,
-  sourceFileName: string,
-  functionName: string,
-  index: number,
-  paramName: string,
-  value: T
-): SourceFileTestCaseMap {
-  return produce(sourceFileTestCases, (draft) => {
-    draft[sourceFileName] = produce(
-      draft[sourceFileName] ?? { sourceFileName, functionTestCases: [] },
-      (draftTestCases) => {
-        const functionTestCaseIndex =
-          draftTestCases.functionTestCases.findIndex(
-            (testCase) => testCase.functionName === functionName
-          ) ?? { functionName, testCases: [] };
-        if (functionTestCaseIndex !== -1) {
-          draftTestCases.functionTestCases[functionTestCaseIndex] =
-            updateFunctionTestCasesInput(
-              draftTestCases.functionTestCases[functionTestCaseIndex],
-              index,
-              paramName,
-              value
-            );
-        } else {
-          draftTestCases.functionTestCases.push(
-            updateFunctionTestCasesInput(
-              { functionName, testCases: [] },
-              index,
-              paramName,
-              value
-            )
-          );
-        }
-      }
-    );
-  });
-}
-
-export function updateSourceFileTestCaseOutput(
-  testCases: SourceFileTestCaseMap,
-  sourceFileName: string,
-  functionName: string,
-  index: number,
-  result: any
-): SourceFileTestCaseMap {
-  return produce(testCases, (draft) => {
-    draft[sourceFileName] = produce(
-      draft[sourceFileName] ?? { sourceFileName, functionTestCases: [] },
-      (draftTestCases) => {
-        const functionTestCaseIndex =
-          draftTestCases.functionTestCases.findIndex(
-            (testCase) => testCase.functionName === functionName
-          ) ?? { functionName, testCases: [] };
-        if (functionTestCaseIndex !== -1) {
-          draftTestCases.functionTestCases[functionTestCaseIndex] =
-            updateFunctionTestCasesOutput(
-              draftTestCases.functionTestCases[functionTestCaseIndex],
-              index,
-              result
-            );
-        } else {
-          draftTestCases.functionTestCases.push(
-            updateFunctionTestCasesOutput(
-              { functionName, testCases: [] },
-              index,
-              result
-            )
-          );
-        }
-      }
-    );
-  });
-}
-
-function updateFunctionTestCaseOutput<T>(
-  functionTestCase: FunctionTestCase,
-  value: T
-): FunctionTestCase {
-  return produce(functionTestCase, (draft) => {
-    draft.output.current = value;
-  });
-}
-
-function updateFunctionTestCasesOutput<T>(
-  functionTestCases: FunctionTestCases,
-  index: number,
-  value: T
-): FunctionTestCases {
-  return produce(functionTestCases, (draft) => {
-    draft.testCases = produce(draft.testCases, (draftTestCases) => {
-      draftTestCases[index] = updateFunctionTestCaseOutput(
-        draftTestCases[index] ?? emptyTestCase,
-        value
-      );
-    });
-  });
-}
-
 function updateFunctionTestCase(
   functionTestCases: FunctionTestCases,
   index: number,
-  updater: (testCase: FunctionTestCase) => FunctionTestCase
+  updater: (testCase?: FunctionTestCase) => FunctionTestCase
 ): FunctionTestCases {
   return produce(functionTestCases, (draft) => {
     draft.testCases = produce(draft.testCases, (draftTestCases) => {
@@ -242,7 +107,7 @@ export function updateSourceFileTestCase(
   sourceFileName: string,
   functionName: string,
   index: number,
-  updater: (prevTestCase: FunctionTestCase) => FunctionTestCase
+  updater: (prevTestCase?: FunctionTestCase) => FunctionTestCase
 ) {
   return produce(sourceFileTestCases, (draft) => {
     draft[sourceFileName] = produce(

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -125,6 +125,7 @@ function updateFunctionTestCasesInput<T>(
     });
   });
 }
+
 export function updateSourcefileTestCaseInput<T>(
   sourceFileTestCases: SourceFileTestCaseMap,
   sourceFileName: string,
@@ -221,5 +222,53 @@ function updateFunctionTestCasesOutput<T>(
         value
       );
     });
+  });
+}
+
+function updateFunctionTestCase(
+  functionTestCases: FunctionTestCases,
+  index: number,
+  updater: (testCase: FunctionTestCase) => FunctionTestCase
+): FunctionTestCases {
+  return produce(functionTestCases, (draft) => {
+    draft.testCases = produce(draft.testCases, (draftTestCases) => {
+      draftTestCases[index] = updater(draftTestCases[index]);
+    });
+  });
+}
+
+export function updateSourceFileTestCase(
+  sourceFileTestCases: SourceFileTestCaseMap,
+  sourceFileName: string,
+  functionName: string,
+  index: number,
+  updater: (prevTestCase: FunctionTestCase) => FunctionTestCase
+) {
+  return produce(sourceFileTestCases, (draft) => {
+    draft[sourceFileName] = produce(
+      draft[sourceFileName] ?? { sourceFileName, functionTestCases: [] },
+      (draftTestCases) => {
+        const functionTestCaseIndex =
+          draftTestCases.functionTestCases.findIndex(
+            (testCase) => testCase.functionName === functionName
+          ) ?? { functionName, testCases: [] };
+        if (functionTestCaseIndex !== -1) {
+          draftTestCases.functionTestCases[functionTestCaseIndex] =
+            updateFunctionTestCase(
+              draftTestCases.functionTestCases[functionTestCaseIndex],
+              index,
+              updater
+            );
+        } else {
+          draftTestCases.functionTestCases.push(
+            updateFunctionTestCase(
+              { functionName, testCases: [] },
+              index,
+              updater
+            )
+          );
+        }
+      }
+    );
   });
 }

--- a/vsc-extension/src-views/components/ExtensionState.tsx
+++ b/vsc-extension/src-views/components/ExtensionState.tsx
@@ -36,18 +36,30 @@ function useExtensionStateInternal() {
     window.addEventListener("message", (event) => {
       const message: ImaginaryMessage = event.data;
 
-      console.log(
-        `[${window.origin}] Got ${message.id} from ${event.origin} /`,
-        event
-      );
       if (message.id === "rpc") {
         // Called when we get a response from a call - rpcMessage will be the resolution of the promise
         const [rpcMessage, transfer] = message.params;
+        if (rpcMessage.id === "resolve_transaction") {
+          console.log(
+            `[${window.origin}] <= Return from call #${rpcMessage.transactionId}: `,
+            rpcMessage.payload
+          );
+        } else {
+          console.log(
+            `[${window.origin}] => Calling ${rpcMessage.id} #${rpcMessage.transactionId} with parameters`,
+            rpcMessage.payload
+          );
+        }
         if (transfer?.length) {
           console.error("Unexpected transfer param from 'rpc' message");
         }
         rpcProvider.dispatch(rpcMessage);
         return;
+      } else {
+        console.log(
+          `[${window.origin}] Got "${message.id}" from ${event.origin} /`,
+          event
+        );
       }
       console.error("unknown message recieved");
     });

--- a/vsc-extension/src-views/components/InputPanel.tsx
+++ b/vsc-extension/src-views/components/InputPanel.tsx
@@ -10,7 +10,11 @@ import {
   FunctionTestCase,
   SerializableFunctionDeclaration,
 } from "../../src-shared/source-info";
-import { addFunctionTestCase, findTestCases } from "../../src-shared/testcases";
+import {
+  addFunctionTestCase,
+  blankTestCase,
+  findTestCases,
+} from "../../src-shared/testcases";
 import {
   selectedFunctionState,
   selectedTestCaseIndexState,
@@ -18,15 +22,6 @@ import {
   testCasesState,
 } from "../shared/state";
 import { TestCaseEditor } from "./TestCaseEditor";
-
-const blankTestCase: FunctionTestCase = {
-  name: "New test",
-  inputs: {},
-  output: {
-    prev: null,
-    current: null,
-  },
-};
 
 // wrapper designed to reset the InputPanel state when the selected function changes. see
 // https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes

--- a/vsc-extension/src-views/components/InputPanel.tsx
+++ b/vsc-extension/src-views/components/InputPanel.tsx
@@ -19,7 +19,7 @@ import {
 } from "../shared/state";
 import { TestCaseEditor } from "./TestCaseEditor";
 
-const blankTestCase = {
+const blankTestCase: FunctionTestCase = {
   name: "New test",
   inputs: {},
   output: {
@@ -55,11 +55,11 @@ export const InputPanelForFunction = () => {
   const onUpdateTestCase = (paramName: string, value: string) => {
     setNewTestCase((prevTestCase) => {
       return {
-        name: prevTestCase.name,
-        inputs: Object.assign({}, prevTestCase.inputs, {
+        ...prevTestCase,
+        inputs: {
+          ...prevTestCase.inputs,
           [paramName]: value,
-        }),
-        output: prevTestCase.output,
+        },
       };
     });
   };

--- a/vsc-extension/src-views/components/InputPanel.tsx
+++ b/vsc-extension/src-views/components/InputPanel.tsx
@@ -1,20 +1,11 @@
-import {
-  VSCodeButton,
-  VSCodeDropdown,
-  VSCodeOption,
-} from "@vscode/webview-ui-toolkit/react";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import React, { useCallback, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import {
   findMatchingFunction,
   FunctionTestCase,
-  SerializableFunctionDeclaration,
 } from "../../src-shared/source-info";
-import {
-  addFunctionTestCase,
-  blankTestCase,
-  findTestCases,
-} from "../../src-shared/testcases";
+import { addFunctionTestCase, blankTestCase } from "../../src-shared/testcases";
 import {
   selectedFunctionState,
   selectedTestCaseIndexState,
@@ -113,9 +104,7 @@ export const InputPanelForFunction = () => {
   if (!selectedFunction) {
     return <p>No function selected</p>;
   }
-  const { fileName, functionName } = selectedFunction;
 
-  const functionTestCases = findTestCases(testCases, fileName, functionName);
   const selectedFunctionInfo = findMatchingFunction(sources, selectedFunction);
   if (!selectedFunctionInfo) {
     console.log("could not find ", selectedFunction, " in ", sources);
@@ -125,27 +114,7 @@ export const InputPanelForFunction = () => {
       <div>
         Test cases for <code>{selectedFunction.functionName}</code>
       </div>
-      {!functionTestCases && (
-        <div>
-          <i>No test cases yet</i>
-        </div>
-      )}
-      {!!functionTestCases && (
-        <VSCodeDropdown
-          onChange={(e) => {
-            const indexStr = (e.target as HTMLOptionElement).value;
-            const index = parseInt(indexStr);
-            setSelectedTestCaseIndex(index);
-          }}
-          value={`${selectedTestCaseIndex}`}
-        >
-          {functionTestCases.testCases.map((testCase, index) => (
-            <VSCodeOption key={index} value={`${index}`}>
-              {formatTestCase(selectedFunctionInfo, testCase)}
-            </VSCodeOption>
-          ))}
-        </VSCodeDropdown>
-      )}
+
       <TestCaseEditor
         selectedFunctionInfo={selectedFunctionInfo}
         selectedTestCase={newTestCase}
@@ -157,26 +126,3 @@ export const InputPanelForFunction = () => {
     </div>
   );
 };
-
-function formatTestCase(
-  fnDecl: SerializableFunctionDeclaration | undefined,
-  testCase: FunctionTestCase
-) {
-  if (!fnDecl) {
-    return "<no declaration>";
-  }
-  if (fnDecl.parameters.length === 1) {
-    return testCase.inputs[fnDecl.parameters[0].name];
-  }
-  if (fnDecl.parameters.length === 0) {
-    return "<no parameters>";
-  }
-  const name = fnDecl.parameters
-    .filter((param) => param.name in testCase.inputs)
-    .map((param) => `${param.name}:${testCase.inputs[param.name]}`)
-    .join(",");
-  if (!name) {
-    return "<new>";
-  }
-  return name;
-}

--- a/vsc-extension/src-views/components/OutputPanel.tsx
+++ b/vsc-extension/src-views/components/OutputPanel.tsx
@@ -59,7 +59,14 @@ export function OutputPanel() {
     )?.testCases ?? [];
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+        marginTop: "1rem",
+      }}
+    >
       {!!fn && <code style={{ whiteSpace: "nowrap" }}>{fn.declaration}</code>}
       <div style={{ display: "flex", flexDirection: "row", gap: "1rem" }}>
         <TestCasesList

--- a/vsc-extension/src-views/components/OutputPanel.tsx
+++ b/vsc-extension/src-views/components/OutputPanel.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { findMatchingFunction } from "../../src-shared/source-info";
 import {
+  blankTestCase,
   findTestCases,
-  updateSourcefileTestCaseInput,
+  updateSourceFileTestCase,
 } from "../../src-shared/testcases";
 import {
   selectedFunctionState,
@@ -33,13 +34,19 @@ export function OutputPanel() {
     const { fileName, functionName } = selectedFunction;
 
     setTestCases((prevFileTestCases) => {
-      return updateSourcefileTestCaseInput(
+      return updateSourceFileTestCase(
         prevFileTestCases,
         fileName,
         functionName,
         testIndex,
-        paramName,
-        value
+        (prevTestCase) => ({
+          ...blankTestCase,
+          ...prevTestCase,
+          inputs: {
+            ...prevTestCase?.inputs,
+            [paramName]: value,
+          },
+        })
       );
     });
   };

--- a/vsc-extension/src-views/components/RunButton.tsx
+++ b/vsc-extension/src-views/components/RunButton.tsx
@@ -19,6 +19,11 @@ export const RunButton: FC<{
         functionName,
         testCaseIndex,
       });
+      await rpcProvider?.rpc("guessTestName", {
+        fileName,
+        functionName,
+        testCaseIndex,
+      });
     } catch (ex) {
       console.error(`Failure to run: ${ex}`, ex);
     } finally {

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -124,7 +124,6 @@ export function makeRpcHandlers(
       testCaseIndex: number;
     }) {
       console.log(
-        "[Extension Host] ",
         `runTestCase: ${fileName}, ${functionName}, ${testCaseIndex}`
       );
       const testCases = state.get("testCases");

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -7,6 +7,7 @@ import ts from "typescript";
 import * as vscode from "vscode";
 import {
   findTestCase,
+  updateSourceFileTestCase,
   updateSourceFileTestCaseOutput,
 } from "../src-shared/testcases";
 import { ExtensionHostState } from "./util/extension-state";
@@ -247,6 +248,24 @@ export function makeRpcHandlers(
         testCase.inputs
       );
       console.log("got test name = ", testName);
+      if (!testCase.hasCustomName) {
+        state.set(
+          "testCases",
+          updateSourceFileTestCase(
+            state.get("testCases"),
+            fileName,
+            functionName,
+            testCaseIndex,
+            (prevTestCase) => {
+              return {
+                ...prevTestCase,
+                hasCustomName: true,
+                name: testName,
+              };
+            }
+          )
+        );
+      }
       return testName;
     },
   };

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -187,7 +187,11 @@ export function makeRpcHandlers(
             (prevTestCase) => ({
               ...blankTestCase,
               ...prevTestCase,
-              output: result,
+              output: {
+                ...blankTestCase.output,
+                ...prevTestCase?.output,
+                current: result,
+              },
             })
           )
         );

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -6,6 +6,7 @@ import {
 import ts from "typescript";
 import * as vscode from "vscode";
 import {
+  blankTestCase,
   findTestCase,
   updateSourceFileTestCase,
 } from "../src-shared/testcases";
@@ -185,8 +186,7 @@ export function makeRpcHandlers(
             functionName,
             testCaseIndex,
             (prevTestCase) => ({
-              name: "New test case",
-              inputs: {},
+              ...blankTestCase,
               ...prevTestCase,
               output: result,
             })
@@ -261,8 +261,7 @@ export function makeRpcHandlers(
             functionName,
             testCaseIndex,
             (prevTestCase) => ({
-              inputs: {},
-              output: { current: null, prev: null },
+              ...blankTestCase,
               ...prevTestCase,
               hasCustomName: true,
               name: testName,

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -243,7 +243,6 @@ export function makeRpcHandlers(
         );
       }
 
-      const { fn: fnDeclaration, sourceFile } = functionInfo;
       const imaginaryFunctionDefinition = generateFunctionDefinition(
         extensionLocalState.get("nativeSources"),
         fileName,

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -6,15 +6,15 @@ import {
 import ts from "typescript";
 import * as vscode from "vscode";
 import {
-  findTestCases,
+  findTestCase,
   updateSourceFileTestCaseOutput,
 } from "../src-shared/testcases";
 import { ExtensionHostState } from "./util/extension-state";
-import { SecretsProxy, SECRET_OPENAI_API_KEY } from "./util/secrets";
+import { SecretsProxy } from "./util/secrets";
 import { findNativeFunction } from "./util/source";
 import { State } from "./util/state";
+import { SourceFileMap } from "./util/ts-source";
 import { TypedMap } from "./util/types";
-import { findMatchingFunction } from "../src-shared/source-info";
 
 // THIS IS AN EXAMPLE FUNCTION TO SHOW HOW IMAGINARY FUNCTIONS WORK
 /**
@@ -26,7 +26,7 @@ import { findMatchingFunction } from "../src-shared/source-info";
 declare function getRandomZooAnimal(): Promise<string>;
 
 /**
- * This function takes in TypeScript function declarations and gives lists of good test data for those
+ * This function takes in a TypeScript function declaration and gives lists of good test data for those
  * functions. For each function passed in, it returns 5 full sets of test parameters. Each set of test data
  * has a value for each of the function's parameters (although the values can sometimes be null or undefined,
  * if the function specification allows it). Each of the arguments it gives is a JSON-compliant object or
@@ -53,6 +53,34 @@ declare function generateTestParametersForTypeScriptFunction(
   functionDeclaration: string
 ): Promise<Record<string, any>[]>;
 
+/**
+ * This function takes in a TypeScript function declaration as a string, and an
+ * example set of parameters that would be passed to that function. This
+ * combination of function and parameters is called a test case. This function returns
+ * a name for that test case.
+ *
+ * The test case name should be human-readable, descriptive, but terse. There will be many test
+ * cases for this function, so the name should be more descriptive of the
+ * paramters than the function itself.
+ *
+ * For instance for a function like this:
+ * ```
+ * function runQuery(tableName: string, queryString: string);
+ * ```
+ * and parameters like this:
+ * ```
+ *  { tableName: "people", queryString: "fred" }
+ * ```
+ *
+ * A good name for this case would be `people / fred`
+ *
+ * @imaginary
+ */
+declare function generateTestCaseName(
+  functionDeclaration: string,
+  parameters: Record<string, any>
+): Promise<string>;
+
 const OPENAI_API_SECRET_KEY = "openaiApiKey";
 export function makeRpcHandlers(
   extensionContext: vscode.ExtensionContext,
@@ -71,33 +99,12 @@ export function makeRpcHandlers(
       fileName: string;
       functionName: string;
     }) {
-      const functionInfo = findNativeFunction(
-        extensionLocalState.get("nativeSources"),
+      const nativeSources = extensionLocalState.get("nativeSources");
+      const imaginaryFunctionDefinition = generateFunctionDefinition(
+        nativeSources,
         fileName,
         functionName
       );
-      if (!functionInfo) {
-        console.error(
-          "failure 2",
-          `Unable to find function declaration for ${functionName} in ${fileName}`
-        );
-        throw new Error(
-          `Unable to find function declaration for ${functionName} in ${fileName}`
-        );
-      }
-      const { fn: fnDeclaration, sourceFile } = functionInfo;
-      console.log("getting comments from ", fnDeclaration, sourceFile);
-      const funcComment = getImaginaryTsDocComments(
-        fnDeclaration,
-        sourceFile
-      )[0];
-
-      const fn = findMatchingFunction(
-        state.get("sources"),
-        state.get("selectedFunction")
-      );
-
-      const imaginaryFunctionDefinition = funcComment + "\n" + fn?.declaration;
       return generateTestParametersForTypeScriptFunction(
         imaginaryFunctionDefinition
       );
@@ -116,19 +123,18 @@ export function makeRpcHandlers(
         "[Extension Host] ",
         `runTestCase: ${fileName}, ${functionName}, ${testCaseIndex}`
       );
-      const testCases = findTestCases(
-        state.get("testCases"),
+      const testCases = state.get("testCases");
+      const testCase = findTestCase(
+        testCases,
         fileName,
-        functionName
+        functionName,
+        testCaseIndex
       );
-      if (!testCases || testCaseIndex >= testCases.testCases.length) {
-        const message = `Trying to run test case #${testCaseIndex} with ${
-          testCases?.testCases.length ?? 0
-        } test cases`;
+      if (!testCase) {
+        const message = `Could not find test case #${testCaseIndex} for ${fileName} ${functionName}`;
         console.error(message);
         throw new Error(message);
       }
-      const testCase = testCases.testCases[testCaseIndex];
       const functionInfo = findNativeFunction(
         extensionLocalState.get("nativeSources"),
         fileName,
@@ -188,7 +194,92 @@ export function makeRpcHandlers(
     async clearApiKey() {
       await secretsProxy.clearSecret(OPENAI_API_SECRET_KEY);
     },
+
+    async guessTestName({
+      fileName,
+      functionName,
+      testCaseIndex,
+    }: {
+      fileName: string;
+      functionName: string;
+      testCaseIndex: number;
+    }) {
+      const functionInfo = findNativeFunction(
+        extensionLocalState.get("nativeSources"),
+        fileName,
+        functionName
+      );
+      const testCases = state.get("testCases");
+      const testCase = findTestCase(
+        testCases,
+        fileName,
+        functionName,
+        testCaseIndex
+      );
+      if (!testCase) {
+        const message = `Could not find test case #${testCaseIndex} for ${fileName} ${functionName}`;
+        console.error(message);
+        throw new Error(message);
+      }
+
+      if (!functionInfo) {
+        console.error(
+          "failure 2",
+          `Unable to find function declaration for ${functionName} in ${fileName}`
+        );
+        throw new Error(
+          `Unable to find function declaration for ${functionName} in ${fileName}`
+        );
+      }
+
+      const { fn: fnDeclaration, sourceFile } = functionInfo;
+      console.log("getting comments from ", fnDeclaration, sourceFile);
+      const imaginaryFunctionDefinition = generateFunctionDefinition(
+        extensionLocalState.get("nativeSources"),
+        fileName,
+        functionName
+      );
+      const testName = await generateTestCaseName(
+        imaginaryFunctionDefinition,
+        testCase.inputs
+      );
+      console.log("got test name = ", testName);
+      return testName;
+    },
   };
+}
+
+function generateFunctionDefinition(
+  nativeSources: SourceFileMap,
+  fileName: string,
+  functionName: string
+) {
+  const functionInfo = findNativeFunction(
+    nativeSources,
+    fileName,
+    functionName
+  );
+  if (!functionInfo) {
+    console.error(
+      "failure 2",
+      `Unable to find function declaration for ${functionName} in ${fileName}`
+    );
+    throw new Error(
+      `Unable to find function declaration for ${functionName} in ${fileName}`
+    );
+  }
+  const { fn: fnDeclaration, sourceFile } = functionInfo;
+  console.log("getting comments from ", fnDeclaration, sourceFile);
+
+  const printer = ts.createPrinter();
+  const printed = printer.printNode(
+    ts.EmitHint.Unspecified,
+    fnDeclaration,
+    sourceFile
+  );
+  console.log("comparing printed = ", printed);
+
+  return printed;
 }
 
 /** This just gets all the types as `any`, since we do not have a ts.TypeChecker available */

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -8,7 +8,6 @@ import * as vscode from "vscode";
 import {
   findTestCase,
   updateSourceFileTestCase,
-  updateSourceFileTestCaseOutput,
 } from "../src-shared/testcases";
 import { ExtensionHostState } from "./util/extension-state";
 import { SecretsProxy } from "./util/secrets";
@@ -180,12 +179,17 @@ export function makeRpcHandlers(
         console.log("got result: ", typeof result, ": ", result);
         state.set(
           "testCases",
-          updateSourceFileTestCaseOutput(
+          updateSourceFileTestCase(
             state.get("testCases"),
             fileName,
             functionName,
             testCaseIndex,
-            result
+            (prevTestCase) => ({
+              name: "New test case",
+              inputs: {},
+              ...prevTestCase,
+              output: result,
+            })
           )
         );
         return result;
@@ -256,13 +260,13 @@ export function makeRpcHandlers(
             fileName,
             functionName,
             testCaseIndex,
-            (prevTestCase) => {
-              return {
-                ...prevTestCase,
-                hasCustomName: true,
-                name: testName,
-              };
-            }
+            (prevTestCase) => ({
+              inputs: {},
+              output: { current: null, prev: null },
+              ...prevTestCase,
+              hasCustomName: true,
+              name: testName,
+            })
           )
         );
       }

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -56,14 +56,17 @@ declare function generateTestParametersForTypeScriptFunction(
 /**
  * This function takes in a TypeScript function declaration as a string, and an
  * example set of parameters that would be passed to that function. This
- * combination of function and parameters is called a test case. This function returns
- * a name for that test case.
+ * combination of function and parameters is called a test case. This function
+ * returns a name for that test case.
  *
- * The test case name should be human-readable, descriptive, but terse. There will be many test
- * cases for this function, so the name should be more descriptive of the
- * paramters than the function itself.
+ * The test case name should be human-readable, descriptive, but terse. There
+ * will be many test cases for this function, so the name should be more
+ * descriptive of the paramters than the function itself.
  *
- * For instance for a function like this:
+ * For test cases with a single, primitive parameter, the name should just be
+ * the value of that parameter as a english, human-readable string of no more than 4 words.
+ *
+ * For a more complex example, with a function like:
  * ```
  * function runQuery(tableName: string, queryString: string);
  * ```

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -150,7 +150,6 @@ export function makeRpcHandlers(
         throw new Error(message);
       }
       const { fn, sourceFile } = functionInfo;
-      console.info("getting comments from ", fn, sourceFile);
       const funcComment = getImaginaryTsDocComments(fn, sourceFile)[0];
 
       console.info("getting api key");
@@ -241,7 +240,6 @@ export function makeRpcHandlers(
       }
 
       const { fn: fnDeclaration, sourceFile } = functionInfo;
-      console.log("getting comments from ", fnDeclaration, sourceFile);
       const imaginaryFunctionDefinition = generateFunctionDefinition(
         extensionLocalState.get("nativeSources"),
         fileName,
@@ -294,7 +292,6 @@ function generateFunctionDefinition(
     );
   }
   const { fn: fnDeclaration, sourceFile } = functionInfo;
-  console.log("getting comments from ", fnDeclaration, sourceFile);
 
   const printer = ts.createPrinter();
   const printed = printer.printNode(
@@ -302,7 +299,6 @@ function generateFunctionDefinition(
     fnDeclaration,
     sourceFile
   );
-  console.log("comparing printed = ", printed);
 
   return printed;
 }

--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -141,8 +141,19 @@ export class ReactWebViewProvider<
     let messageDispose: vscode.Disposable | null =
       this.webviewView.webview.onDidReceiveMessage((e: ImaginaryMessage) => {
         if (e.id === "rpc") {
-          const [message] = e.params;
-          this.rpcProvider.dispatch(message);
+          const [rpcMessage] = e.params;
+          if (rpcMessage.id === "resolve_transaction") {
+            console.log(
+              ` <= Return from call #${rpcMessage.transactionId}: `,
+              rpcMessage.payload
+            );
+          } else {
+            console.log(
+              ` => Calling ${rpcMessage.id} #${rpcMessage.transactionId} with parameters`,
+              rpcMessage.payload
+            );
+          }
+          this.rpcProvider.dispatch(rpcMessage);
         }
       });
     token.onCancellationRequested((e) => {


### PR DESCRIPTION
- add optional hasCustomName
- add findTestCase for reuse elsewhere
- add rpc for guessing a test name, and consolidate some code
- refined comment
- update the test case name if it does not already have one
- consolidate test input updates
