### PR TITLE
Add version envelope to persisted json, format line-by-line

### DIFF
--- a/vsc-extension/jest.config.ts
+++ b/vsc-extension/jest.config.ts
@@ -10,8 +10,9 @@ const jestConfig: JestConfigWithTsJest = {
   }),
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
   collectCoverageFrom: [
-    "<rootDir>/src/**/*.{ts,tsx}",
-    "<rootDir>/src-*/**/*.{ts,tsx}",
+    // TODO: include tsx for (eventual) react tests
+    "<rootDir>/src/**/*.ts",
+    "<rootDir>/src-*/**/*.ts",
   ],
 };
 

--- a/vsc-extension/src/util/persistence.test.ts
+++ b/vsc-extension/src/util/persistence.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vscode from "vscode";
+import {
+  SourceFileTestCaseMap,
+  SourceFileTestCases,
+} from "../../src-shared/source-info";
+import { loadTestCases, writeAllTestCases } from "./persistence";
+
+// Helper function to create a temporary directory for testing
+async function createTempDirectory(): Promise<string> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "temp-"));
+  return tempDir;
+}
+
+jest.mock("vscode", () => {
+  const { URI: Uri, Utils } = jest.requireActual("vscode-uri");
+  Uri.joinPath = Utils.joinPath;
+  return {
+    Uri,
+    workspace: {
+      workspaceFolders: [],
+    },
+  };
+});
+describe("persistence", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDirectory();
+    (vscode.workspace.workspaceFolders as any) = [
+      { uri: vscode.Uri.file(tempDir), name: "root", index: 0 },
+    ] satisfies vscode.WorkspaceFolder[];
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("writeAllTestCases", () => {
+    it("should write all test cases to the appropriate files", async () => {
+      const testCases: SourceFileTestCaseMap = {
+        "example.ts": {
+          sourceFileName: "example.ts",
+          functionTestCases: [
+            {
+              functionName: "add",
+              testCases: [
+                {
+                  name: "add positive numbers",
+                  inputs: { a: 1, b: 2 },
+                  output: {
+                    prev: 3,
+                    current: 3,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      await writeAllTestCases(testCases);
+
+      const savedTestCases = await loadTestCases("example.ts");
+      expect(savedTestCases).toEqual(testCases["example.ts"]);
+    });
+  });
+
+  describe("loadTestCases", () => {
+    it("should load test cases from a given file", async () => {
+      const testCases: SourceFileTestCases = {
+        sourceFileName: "example.ts",
+        functionTestCases: [
+          {
+            functionName: "add",
+            testCases: [
+              {
+                name: "add positive numbers",
+                inputs: { a: 1, b: 2 },
+                output: {
+                  prev: 3,
+                  current: 3,
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const testCaseFilename = "example.ipsnapshot.json";
+      await fs.writeFile(
+        path.join(tempDir, testCaseFilename),
+        JSON.stringify(
+          { version: "0.1", testCases: testCases.functionTestCases },
+          null,
+          2
+        )
+      );
+
+      const loadedTestCases = await loadTestCases("example.ts");
+      expect(loadedTestCases).toEqual(testCases);
+    });
+
+    it("should return an empty object if the test case file does not exist", async () => {
+      const loadedTestCases = await loadTestCases("nonexistent.ts");
+      expect(loadedTestCases).toEqual({
+        sourceFileName: "nonexistent.ts",
+        functionTestCases: [],
+      });
+    });
+  });
+});

--- a/vsc-extension/src/util/persistence.ts
+++ b/vsc-extension/src/util/persistence.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  FunctionTestCases,
+  SourceFileTestCaseMap,
+  SourceFileTestCases,
+} from "../../src-shared/source-info";
+import { getAbsolutePathInProject } from "./editor";
+
+/** This is the envelope that test cases are written with */
+interface TestCaseFile {
+  version: "0.1";
+
+  testCases: FunctionTestCases[];
+}
+
+export async function writeAllTestCases(testCases: SourceFileTestCaseMap) {
+  const promises = Object.values(testCases).map((value) => {
+    if (!value.functionTestCases.length) {
+      return;
+    }
+    return writeSourceFileTestCases(value);
+  });
+  await Promise.all(promises);
+}
+function writeSourceFileTestCases(
+  value: SourceFileTestCases
+): Promise<void> | undefined {
+  const testCaseFile: TestCaseFile = {
+    testCases: value.functionTestCases,
+    version: "0.1",
+  };
+  return fs.writeFile(
+    getAbsolutePathInProject(getTestCaseFilename(value.sourceFileName)),
+    JSON.stringify(testCaseFile, null, 2)
+  );
+}
+export async function loadTestCases(
+  sourceFileName: string
+): Promise<SourceFileTestCases> {
+  const testCaseFileName = getAbsolutePathInProject(
+    getTestCaseFilename(sourceFileName)
+  );
+  try {
+    const testCasesRaw = await fs.readFile(testCaseFileName, {
+      encoding: "utf-8",
+    });
+    const testCaseFile: TestCaseFile = JSON.parse(testCasesRaw);
+    const version = testCaseFile.version;
+
+    if (version !== "0.1") {
+      console.warn(`Reading in unknown version: ${version}`);
+    }
+    return {
+      sourceFileName,
+      functionTestCases: testCaseFile.testCases,
+    };
+  } catch (ex) {
+    console.warn(`Unable to load test cases for ${sourceFileName}:`, ex);
+    return { sourceFileName, functionTestCases: [] };
+  }
+}
+function getTestCaseFilename(sourceFileName: string) {
+  const parsedPath = path.parse(sourceFileName);
+  // TODO: should we retain the current extension somewhere?
+  parsedPath.ext = `.ipsnapshot.json`;
+  parsedPath.base = `${parsedPath.name}${parsedPath.ext}`;
+  return path.format(parsedPath);
+}

--- a/vsc-extension/src/util/watched-map.test.ts
+++ b/vsc-extension/src/util/watched-map.test.ts
@@ -1,0 +1,59 @@
+import { TypedMap } from "./types";
+import { createWatchedMap } from "./watched-map";
+
+// Mocking the vscode module and EventEmitter
+jest.mock("vscode", () => {
+  return {
+    fire: jest.fn(),
+    EventEmitter: jest.fn().mockImplementation(function () {
+      this.fire = jest.fn();
+      this.event = jest.fn();
+      return this;
+    }),
+  };
+});
+
+// Importing the mocked vscode module
+import vscode from "vscode";
+
+describe("watched-map", () => {
+  let typedMap: TypedMap<{ name: string; age: number }>;
+  const EventEmitter = jest.mocked(vscode.EventEmitter);
+
+  beforeEach(() => {
+    typedMap = new Map() as TypedMap<{ name: string; age: number }>;
+  });
+
+  describe("createWatchedMap", () => {
+    it("should create a watched map that fires events on state change", () => {
+      const watchedMap = createWatchedMap(typedMap);
+
+      // Setting values in the watched map
+      watchedMap.set("name", "John");
+      watchedMap.set("age", 30);
+
+      // Checking if EventEmitter is called correctly
+      expect(EventEmitter).toHaveBeenCalledTimes(1);
+
+      // Checking if fire method of EventEmitter is called with correct values
+      expect(EventEmitter.mock.instances[0].fire).toHaveBeenCalledTimes(2);
+      expect(EventEmitter.mock.instances[0].fire).toHaveBeenNthCalledWith(1, {
+        name: "John",
+      });
+      expect(EventEmitter.mock.instances[0].fire).toHaveBeenNthCalledWith(2, {
+        age: 30,
+      });
+    });
+
+    it("should return the correct values when getting values from the watched map", () => {
+      const watchedMap = createWatchedMap(typedMap);
+
+      // Setting and getting values in the watched map
+      watchedMap.set("name", "John");
+      watchedMap.set("age", 30);
+
+      expect(watchedMap.get("name")).toEqual("John");
+      expect(watchedMap.get("age")).toEqual(30);
+    });
+  });
+});


### PR DESCRIPTION
- add a versioned envelope
- tests
- quiet down coverage problems
- tests for watched-map
- some better mocks
