### PR TITLE
Break test outputs out from test cases themselves, so they can be saved separately

### DIFF
--- a/vsc-extension/src-shared/source-info.ts
+++ b/vsc-extension/src-shared/source-info.ts
@@ -7,15 +7,6 @@ export interface FunctionTestCase {
   /** Set if the user manually sets the name */
   hasCustomName?: boolean;
   inputs: Record<string, any>;
-  /**
-   * The outputs from running the function with these inputs
-   * TODO: move these elsewhere?
-   **/
-  output: {
-    // corresponds to the current output on HEAD
-    prev: any;
-    current: any;
-  };
 
   serviceParameters?: ServiceParameters;
 }
@@ -98,4 +89,25 @@ export function findMatchingFunction(
     (fn) => fn.name === selectedFunction.functionName
   );
   return matchingFunction;
+}
+
+export type SourceFileTestOutputMap = Record<string, SourceFileTestOutput>;
+
+/** Test outputs for all functions in a file */
+export interface SourceFileTestOutput {
+  sourceFileName: string;
+  functionOutputs: FunctionTestOutput[];
+}
+
+/** Test outputs for a function */
+export interface FunctionTestOutput {
+  functionName: string;
+  outputs: TestOutput[];
+}
+
+/** Test output results and metadata */
+export interface TestOutput {
+  output: any;
+  /** ISO8601 date? */
+  lastRun: string;
 }

--- a/vsc-extension/src-shared/testcases.test.ts
+++ b/vsc-extension/src-shared/testcases.test.ts
@@ -77,12 +77,10 @@ describe("addFunctionTestCase", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 1, b: 2 },
-                output: { prev: null, current: null },
               },
               {
                 name: "Test case 2",
                 inputs: { a: 3, b: 4 },
-                output: { prev: null, current: null },
               },
             ],
           },
@@ -154,7 +152,6 @@ describe("findTestCases", () => {
         {
           name: "Test case 1",
           inputs: { a: 1, b: 2 },
-          output: { prev: null, current: null },
         },
       ],
     });
@@ -209,7 +206,6 @@ describe("updateSourcefileTestCase", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 3, b: 2 },
-                output: { prev: null, current: null },
               },
             ],
           },
@@ -257,7 +253,6 @@ describe("updateSourcefileTestCase", () => {
               {
                 name: "New test",
                 inputs: { a: 1 },
-                output: { prev: null, current: null },
               },
             ],
           },
@@ -312,12 +307,10 @@ describe("updateSourcefileTestCase", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 1, b: 2 },
-                output: { prev: null, current: null },
               },
               {
                 name: "New test",
                 inputs: { a: 3 },
-                output: { prev: null, current: null },
               },
             ],
           },

--- a/vsc-extension/src-shared/testcases.test.ts
+++ b/vsc-extension/src-shared/testcases.test.ts
@@ -14,7 +14,6 @@ describe("addFunctionTestCase", () => {
     const newTestCase: FunctionTestCase = {
       name: "Test case 1",
       inputs: { a: 1, b: 2 },
-      output: { prev: null, current: null },
     };
 
     const result = addFunctionTestCase(
@@ -48,7 +47,6 @@ describe("addFunctionTestCase", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 1, b: 2 },
-                output: { prev: null, current: null },
               },
             ],
           },
@@ -60,7 +58,6 @@ describe("addFunctionTestCase", () => {
     const newTestCase: FunctionTestCase = {
       name: "Test case 2",
       inputs: { a: 3, b: 4 },
-      output: { prev: null, current: null },
     };
 
     const result = addFunctionTestCase(
@@ -107,7 +104,6 @@ describe("findTestCases", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 1, b: 2 },
-                output: { prev: null, current: null },
               },
             ],
           },
@@ -137,7 +133,6 @@ describe("findTestCases", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 1, b: 2 },
-                output: { prev: null, current: null },
               },
             ],
           },
@@ -178,7 +173,6 @@ describe("updateSourcefileTestCase", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 1, b: 2 },
-                output: { prev: null, current: null },
               },
             ],
           },
@@ -283,7 +277,6 @@ describe("updateSourcefileTestCase", () => {
               {
                 name: "Test case 1",
                 inputs: { a: 1, b: 2 },
-                output: { prev: null, current: null },
               },
             ],
           },

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -137,6 +137,40 @@ export function findTestCase(
   return testCase;
 }
 
+export function findTestOutputs(
+  testOutputs: SourceFileTestOutputMap,
+  fileName?: string,
+  functionNameTarget?: string
+): FunctionTestOutput | undefined {
+  if (!fileName || !functionNameTarget) {
+    return;
+  }
+  return testOutputs[fileName]?.functionOutputs.find(
+    ({ functionName }) => functionName === functionNameTarget
+  );
+}
+
+export function findTestOutput(
+  testOutputs: SourceFileTestOutputMap,
+  fileName: string,
+  functionName: string,
+  testCaseIndex: number
+): TestOutput | null {
+  const functionTestOutput = findTestOutputs(
+    testOutputs,
+    fileName,
+    functionName
+  );
+  if (
+    !functionTestOutput ||
+    testCaseIndex >= functionTestOutput.outputs.length
+  ) {
+    return null;
+  }
+  const testCase = functionTestOutput.outputs[testCaseIndex];
+  return testCase;
+}
+
 function updateFunctionTestCase(
   functionTestCases: FunctionTestCases,
   index: number,

--- a/vsc-extension/src-shared/testcases.ts
+++ b/vsc-extension/src-shared/testcases.ts
@@ -14,6 +14,11 @@ export const blankTestCase: FunctionTestCase = {
   inputs: {},
 };
 
+export const blankTestOutput: TestOutput = {
+  lastRun: "",
+  output: {},
+};
+
 export function deleteFunctionTestCase(
   testCases: SourceFileTestCaseMap,
   sourceFileName: string,

--- a/vsc-extension/src-views/components/GenerateTestCasesButton.tsx
+++ b/vsc-extension/src-views/components/GenerateTestCasesButton.tsx
@@ -1,10 +1,10 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import React, { FC, useState } from "react";
 import { useRecoilState } from "recoil";
 import { SelectedFunction } from "../../src-shared/source-info";
-import { useExtensionState } from "./ExtensionState";
-import { testCasesState } from "../shared/state";
-import React, { FC, useState } from "react";
 import { addFunctionTestCase, findTestCases } from "../../src-shared/testcases";
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { testCasesState } from "../shared/state";
+import { useExtensionState } from "./ExtensionState";
 
 export const GenerateTestCasesButton: FC<{
   selectedFunction: SelectedFunction;
@@ -49,10 +49,6 @@ export const GenerateTestCasesButton: FC<{
             name: newTestCase.__testName,
             hasCustomName: true,
             inputs: Object.assign({}, newTestCase, { __testName: undefined }),
-            output: {
-              prev: null,
-              current: null,
-            },
           }
         );
       });

--- a/vsc-extension/src-views/components/TestCaseDashboard.tsx
+++ b/vsc-extension/src-views/components/TestCaseDashboard.tsx
@@ -1,16 +1,22 @@
 import React, { FC, ReactNode } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import {
   FunctionTestCase,
   SelectedFunction,
   SerializableFunctionDeclaration,
+  TestOutput,
 } from "../../src-shared/source-info";
 import {
   blankTestCase,
   findTestCases,
+  findTestOutputs,
   updateSourceFileTestCase,
 } from "../../src-shared/testcases";
-import { selectedTestCaseIndexState, testCasesState } from "../shared/state";
+import {
+  latestTestOutputState,
+  selectedTestCaseIndexState,
+  testCasesState,
+} from "../shared/state";
 import { ParamEditor } from "./ParamEditor";
 import { TestCasesList } from "./TestCasesList";
 
@@ -30,6 +36,13 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
       selectedFunction?.fileName,
       selectedFunction?.functionName
     )?.testCases ?? [];
+  const testOutputs = useRecoilValue(latestTestOutputState);
+  const testOutputsForSelectedFunction =
+    findTestOutputs(
+      testOutputs,
+      selectedFunction?.fileName,
+      selectedFunction?.functionName
+    )?.outputs ?? [];
 
   const onUpdateTestCase = (paramName: string, value: string) => {
     const { fileName, functionName } = selectedFunction;
@@ -54,6 +67,9 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
   const formattedDeclaration = formatDeclaration(fn);
   const functionTestCase: FunctionTestCase | undefined =
     testCasesForSelectedFunction[testIndex];
+  const functionTestOutput: TestOutput | undefined =
+    testOutputsForSelectedFunction[testIndex];
+
   // if (!functionTestCase) {
   //   console.log("missing functionTestCase for ", testIndex);
   // }
@@ -153,7 +169,7 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
           >
             {functionTestCase && (
               <code style={{ whiteSpace: "pre" }}>
-                {formatOutput(functionTestCase.output.current)}
+                {formatOutput(functionTestOutput?.output)}
               </code>
             )}
           </div>

--- a/vsc-extension/src-views/shared/state.ts
+++ b/vsc-extension/src-views/shared/state.ts
@@ -6,6 +6,7 @@ import {
   SelectedFileTestCases,
   SerializableSourceFileMap,
   SourceFileTestCaseMap,
+  SourceFileTestOutputMap,
 } from "../../src-shared/source-info";
 
 function synced<T>(defaultValue: T, isNullable?: boolean) {
@@ -85,4 +86,10 @@ export const selectedTestCaseIndexState = selectorFamily({
         return v;
       });
     },
+});
+
+export const latestTestOutputState = atom<SourceFileTestOutputMap>({
+  default: {},
+  key: "latestTestOutput",
+  effects: [synced({})],
 });

--- a/vsc-extension/src/extension.ts
+++ b/vsc-extension/src/extension.ts
@@ -31,6 +31,8 @@ const initialState: State = {
   sources: {},
   testCases: {},
   selectedTestCases: {},
+  acceptedTestOutput: {},
+  latestTestOutput: {},
 };
 
 // This method is called when your extension is activated

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -9,6 +9,7 @@ import {
   blankTestCase,
   findTestCase,
   updateSourceFileTestCase,
+  updateSourceFileTestOutput,
 } from "../src-shared/testcases";
 import { ExtensionHostState } from "./util/extension-state";
 import { SecretsProxy } from "./util/secrets";
@@ -187,15 +188,16 @@ export function makeRpcHandlers(
         );
         console.log("got result: ", typeof result, ": ", result);
         state.set(
-          "testCases",
-          updateSourceFileTestCase(
-            state.get("testCases"),
+          "latestTestOutput",
+          updateSourceFileTestOutput(
+            state.get("latestTestOutput"),
             fileName,
             functionName,
             testCaseIndex,
-            (prevTestCase) => ({
-              ...blankTestCase,
-              ...prevTestCase,
+            (output) => ({
+              ...output,
+              output: result,
+              lastRun: new Date().toISOString(),
             })
           )
         );

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -196,11 +196,6 @@ export function makeRpcHandlers(
             (prevTestCase) => ({
               ...blankTestCase,
               ...prevTestCase,
-              output: {
-                ...blankTestCase.output,
-                ...prevTestCase?.output,
-                current: result,
-              },
             })
           )
         );

--- a/vsc-extension/src/util/persistence.test.ts
+++ b/vsc-extension/src/util/persistence.test.ts
@@ -57,7 +57,7 @@ describe("persistence", () => {
         },
       };
 
-      await writeAllTestCases(testCases);
+      await writeAllTestCases(testCases, {});
 
       const savedTestCases = await loadTestCases("example.ts");
       expect(savedTestCases).toEqual(testCases["example.ts"]);

--- a/vsc-extension/src/util/persistence.test.ts
+++ b/vsc-extension/src/util/persistence.test.ts
@@ -60,7 +60,10 @@ describe("persistence", () => {
       await writeAllTestCases(testCases, {});
 
       const savedTestCases = await loadTestCases("example.ts");
-      expect(savedTestCases).toEqual(testCases["example.ts"]);
+      expect(savedTestCases).toEqual({
+        testCases: testCases["example.ts"],
+        testOutputs: { functionOutputs: [], sourceFileName: "example.ts" },
+      });
     });
   });
 
@@ -92,14 +95,23 @@ describe("persistence", () => {
       );
 
       const loadedTestCases = await loadTestCases("example.ts");
-      expect(loadedTestCases).toEqual(testCases);
+      expect(loadedTestCases).toEqual({
+        testCases,
+        testOutputs: { sourceFileName: "example.ts", functionOutputs: [] },
+      });
     });
 
     it("should return an empty object if the test case file does not exist", async () => {
       const loadedTestCases = await loadTestCases("nonexistent.ts");
       expect(loadedTestCases).toEqual({
-        sourceFileName: "nonexistent.ts",
-        functionTestCases: [],
+        testCases: {
+          sourceFileName: "nonexistent.ts",
+          functionTestCases: [],
+        },
+        testOutputs: {
+          sourceFileName: "nonexistent.ts",
+          functionOutputs: [],
+        },
       });
     });
   });

--- a/vsc-extension/src/util/persistence.test.ts
+++ b/vsc-extension/src/util/persistence.test.ts
@@ -50,10 +50,6 @@ describe("persistence", () => {
                 {
                   name: "add positive numbers",
                   inputs: { a: 1, b: 2 },
-                  output: {
-                    prev: 3,
-                    current: 3,
-                  },
                 },
               ],
             },
@@ -79,10 +75,6 @@ describe("persistence", () => {
               {
                 name: "add positive numbers",
                 inputs: { a: 1, b: 2 },
-                output: {
-                  prev: 3,
-                  current: 3,
-                },
               },
             ],
           },

--- a/vsc-extension/src/util/state.ts
+++ b/vsc-extension/src/util/state.ts
@@ -3,6 +3,7 @@ import {
   SelectedFileTestCases,
   SerializableSourceFileMap,
   SourceFileTestCaseMap,
+  SourceFileTestOutputMap,
 } from "../../src-shared/source-info";
 
 export interface State {
@@ -33,4 +34,9 @@ export interface State {
    * This allows each fileName/functionName combination to have its own selected state.
    */
   selectedTestCases: SelectedFileTestCases;
+
+  /** Tests accepted by the current user */
+  acceptedTestOutput: SourceFileTestOutputMap;
+
+  latestTestOutput: SourceFileTestOutputMap;
 }


### PR DESCRIPTION
Fixes #93

- start breaking out test outputs
- fix test cases to account for removal of outputs
- update display to show output from the right place
- now persist outputs
