### PR TITLE
Quick 'n dirty rename (using showInputBox)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2382,10 +2382,6 @@
       "resolved": "transformers/babel",
       "link": true
     },
-    "node_modules/@imaginary-dev/imaginary-programming-extension": {
-      "resolved": "vsc-extension",
-      "link": true
-    },
     "node_modules/@imaginary-dev/nextjs-util": {
       "resolved": "nextjs-util",
       "link": true
@@ -7805,6 +7801,10 @@
         "node": ">= 4"
       }
     },
+    "node_modules/imaginary-programming-extension": {
+      "resolved": "vsc-extension",
+      "link": true
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -9839,14 +9839,14 @@
       }
     },
     "node_modules/next-remove-imports": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/next-remove-imports/-/next-remove-imports-1.0.10.tgz",
-      "integrity": "sha512-BTlwYD86PyU0YuO2/CVfm+82WZiUpkspH7YkzFBM/nua/d8zouw+/4eUhLl278dtZXIlarmhpH47cWwred4w6Q==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/next-remove-imports/-/next-remove-imports-1.0.11.tgz",
+      "integrity": "sha512-i+L8kcP1hM3nOCNv8NWhtJGWwkEDtej0BaRlCzcZDQeXCT3cwaJo4VyD9x4449sbJwj9xt/wmqlH8fg5g8RaYg==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.14.3",
-        "babel-loader": "^9.0.0",
-        "babel-plugin-transform-remove-imports": "^1.5.4"
+        "@babel/core": "^7.21.4",
+        "babel-loader": "^9.1.2",
+        "babel-plugin-transform-remove-imports": "^1.7.0"
       }
     },
     "node_modules/nextjs-blog": {
@@ -13805,7 +13805,7 @@
       }
     },
     "vsc-extension": {
-      "name": "@imaginary-dev/imaginary-programming-extension",
+      "name": "imaginary-programming-extension",
       "version": "0.0.1",
       "dependencies": {
         "@imaginary-dev/runtime": "*",

--- a/vsc-extension/package.json
+++ b/vsc-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@imaginary-dev/imaginary-programming-extension",
+  "name": "imaginary-programming-extension",
   "displayName": "Imaginary Programming",
   "description": "",
   "version": "0.0.1",

--- a/vsc-extension/src-shared/ExtensionRpcProvider.tsx
+++ b/vsc-extension/src-shared/ExtensionRpcProvider.tsx
@@ -1,0 +1,12 @@
+import { RpcProviderInterface } from "worker-rpc";
+import { type ExtensionRpcInterface } from "../src/rpc-handlers";
+import { State } from "../src/util/state";
+import { type RpcCaller } from "../src/util/types";
+
+type StateRpcProvider<S> = {
+  "read-state": (itemKey: keyof S) => Promise<void>;
+  "write-state": (value: Partial<S>) => Promise<void>;
+};
+/** Adds strong typing to the RpcProviderInterface, specifically `rpc("id", {params})` */
+export type ExtensionRpcProvider = Omit<RpcProviderInterface, "rpc"> &
+  RpcCaller<ExtensionRpcInterface & StateRpcProvider<State>>;

--- a/vsc-extension/src-views/components/DebugPanel.tsx
+++ b/vsc-extension/src-views/components/DebugPanel.tsx
@@ -21,7 +21,7 @@ export const DebugPanel: FC = () => {
   const onClearApiKey = useCallback(async () => {
     try {
       setClearing(true);
-      await rpcProvider?.rpc("clearApiKey");
+      await rpcProvider?.rpc("clearApiKey", undefined);
     } finally {
       setClearing(false);
     }

--- a/vsc-extension/src-views/components/ExtensionState.tsx
+++ b/vsc-extension/src-views/components/ExtensionState.tsx
@@ -8,17 +8,14 @@ import React, {
   useState,
 } from "react";
 import { WebviewApi } from "vscode-webview";
-import { RpcProvider, RpcProviderInterface } from "worker-rpc";
+import { RpcProvider } from "worker-rpc";
+import { ExtensionRpcProvider } from "../../src-shared/ExtensionRpcProvider";
 import { ImaginaryMessage } from "../../src-shared/messages";
-import { type ExtensionRpcInterface } from "../../src/rpc-handlers";
-import { type RpcCaller } from "../../src/util/types";
-type MagicRpcProvider = Omit<RpcProviderInterface, "rpc"> &
-  RpcCaller<ExtensionRpcInterface>;
 /** Main hook that wires up all messaging to/from this webview */
 function useExtensionStateInternal() {
   // Local copies of state as broadcast from extension host
   const vscodeRef = useRef<WebviewApi<unknown>>();
-  const [rpcProvider, setRpcProvider] = useState<MagicRpcProvider>();
+  const [rpcProvider, setRpcProvider] = useState<ExtensionRpcProvider>();
 
   // Synchronize states by listening for events
   useEffect(() => {

--- a/vsc-extension/src-views/components/ExtensionState.tsx
+++ b/vsc-extension/src-views/components/ExtensionState.tsx
@@ -8,14 +8,17 @@ import React, {
   useState,
 } from "react";
 import { WebviewApi } from "vscode-webview";
-import { RpcProvider } from "worker-rpc";
+import { RpcProvider, RpcProviderInterface } from "worker-rpc";
 import { ImaginaryMessage } from "../../src-shared/messages";
-
+import { type ExtensionRpcInterface } from "../../src/rpc-handlers";
+import { type RpcCaller } from "../../src/util/types";
+type MagicRpcProvider = Omit<RpcProviderInterface, "rpc"> &
+  RpcCaller<ExtensionRpcInterface>;
 /** Main hook that wires up all messaging to/from this webview */
 function useExtensionStateInternal() {
   // Local copies of state as broadcast from extension host
   const vscodeRef = useRef<WebviewApi<unknown>>();
-  const [rpcProvider, setRpcProvider] = useState<RpcProvider>();
+  const [rpcProvider, setRpcProvider] = useState<MagicRpcProvider>();
 
   // Synchronize states by listening for events
   useEffect(() => {

--- a/vsc-extension/src-views/components/RecoilSyncWebview.tsx
+++ b/vsc-extension/src-views/components/RecoilSyncWebview.tsx
@@ -1,10 +1,13 @@
 import React, { FC, PropsWithChildren, useMemo } from "react";
 import { DefaultValue } from "recoil";
 import { ListenToItems, ReadItem, RecoilSync, WriteItems } from "recoil-sync";
-import { RpcProvider } from "worker-rpc";
+import { ExtensionRpcProvider } from "../../src-shared/ExtensionRpcProvider";
+import { State } from "../../src/util/state";
 import { useExtensionState } from "./ExtensionState";
 
-export const RecoilSyncWebview: FC<PropsWithChildren<{}>> = ({ children }) => {
+export const RecoilSyncWebview: FC<PropsWithChildren<unknown>> = ({
+  children,
+}) => {
   const { rpcProvider } = useExtensionState();
 
   const { reader, writer, listen } = useRpc(rpcProvider);
@@ -19,7 +22,7 @@ export const RecoilSyncWebview: FC<PropsWithChildren<{}>> = ({ children }) => {
   );
 };
 
-function useRpc(rpcProvider: RpcProvider | undefined): {
+function useRpc(rpcProvider: ExtensionRpcProvider | undefined): {
   reader: ReadItem;
   writer: WriteItems;
   listen: ListenToItems;
@@ -31,13 +34,15 @@ function useRpc(rpcProvider: RpcProvider | undefined): {
           console.warn(`[webview] reading ${itemKey} before provider is ready`);
           return new DefaultValue();
         },
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         writer: () => {},
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         listen: () => {},
       };
     }
-    const reader: ReadItem = async (itemKey) => {
+    const reader: ReadItem = async (itemKey: string) => {
       console.log(`[webview ${!!rpcProvider}] reading key: `, itemKey);
-      const value = rpcProvider.rpc("read-state", itemKey);
+      const value = rpcProvider.rpc("read-state", itemKey as keyof State);
       if (value === undefined) {
         return new DefaultValue();
       }

--- a/vsc-extension/src-views/components/RunButton.tsx
+++ b/vsc-extension/src-views/components/RunButton.tsx
@@ -45,7 +45,7 @@ export const RunButton: FC<{
     : "codicon-play";
 
   return (
-    <div className="flex gap-5">
+    <div style={{ display: "flex", gap: "0.25rem" }}>
       <VSCodeButton
         onClick={onDelete}
         disabled={!selectedFunction}

--- a/vsc-extension/src-views/components/RunButton.tsx
+++ b/vsc-extension/src-views/components/RunButton.tsx
@@ -7,7 +7,8 @@ export const RunButton: FC<{
   selectedFunction: MaybeSelectedFunction;
   testCaseIndex: number;
   onDelete: () => void;
-}> = ({ selectedFunction, testCaseIndex, onDelete }) => {
+  onRename: (newName: string) => void;
+}> = ({ selectedFunction, testCaseIndex, onDelete, onRename }) => {
   const { rpcProvider } = useExtensionState();
   const { fileName, functionName } = selectedFunction ?? {};
   const [loading, setLoading] = useState(false);
@@ -44,13 +45,20 @@ export const RunButton: FC<{
     : "codicon-play";
 
   return (
-    <>
+    <div className="flex gap-5">
       <VSCodeButton
         onClick={onDelete}
         disabled={!selectedFunction}
         appearance="icon"
       >
-        <span className="codicon codicon-trash mr-5" />
+        <span className="codicon codicon-trash" />
+      </VSCodeButton>
+      <VSCodeButton
+        onClick={() => onRename("xyz")}
+        disabled={!selectedFunction}
+        appearance="icon"
+      >
+        <span className="codicon codicon-edit" />
       </VSCodeButton>
       <VSCodeButton
         onClick={onRun}
@@ -59,6 +67,6 @@ export const RunButton: FC<{
       >
         <span className={`codicon ${iconClass}`} />
       </VSCodeButton>
-    </>
+    </div>
   );
 };

--- a/vsc-extension/src-views/components/RunButton.tsx
+++ b/vsc-extension/src-views/components/RunButton.tsx
@@ -7,7 +7,7 @@ export const RunButton: FC<{
   selectedFunction: MaybeSelectedFunction;
   testCaseIndex: number;
   onDelete: () => void;
-  onRename: (newName: string) => void;
+  onRename: () => void;
 }> = ({ selectedFunction, testCaseIndex, onDelete, onRename }) => {
   const { rpcProvider } = useExtensionState();
   const { fileName, functionName } = selectedFunction ?? {};
@@ -54,7 +54,7 @@ export const RunButton: FC<{
         <span className="codicon codicon-trash" />
       </VSCodeButton>
       <VSCodeButton
-        onClick={() => onRename("xyz")}
+        onClick={onRename}
         disabled={!selectedFunction}
         appearance="icon"
       >

--- a/vsc-extension/src-views/components/RunButton.tsx
+++ b/vsc-extension/src-views/components/RunButton.tsx
@@ -13,6 +13,9 @@ export const RunButton: FC<{
   const [loading, setLoading] = useState(false);
 
   const onRun = useCallback(async () => {
+    if (!fileName || !functionName) {
+      return;
+    }
     try {
       setLoading(true);
       await rpcProvider?.rpc("runTestCase", {

--- a/vsc-extension/src-views/components/TestCasesList.tsx
+++ b/vsc-extension/src-views/components/TestCasesList.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../src-shared/source-info";
 import {
   deleteFunctionTestCase,
+  findTestCase,
   findTestCases,
 } from "../../src-shared/testcases";
 import { testCasesState } from "../shared/state";
@@ -60,18 +61,24 @@ export const TestCasesList: FC<Props> = ({
     setAllTestCases(newAllTestCases);
   };
 
-  const onRename = async (testCaseIndex: number, newTestName: string) => {
+  const onRename = async (testCaseIndex: number) => {
     if (!fileName) {
       return;
     }
     if (!functionName) {
       return;
     }
+    const currentTestName = findTestCase(
+      allTestCases,
+      fileName,
+      functionName,
+      testCaseIndex
+    )?.name;
     await rpcProvider?.rpc("renameTest", {
       fileName,
       functionName,
       testCaseIndex,
-      newTestName,
+      newTestName: currentTestName,
     });
   };
 
@@ -116,7 +123,7 @@ export const TestCasesList: FC<Props> = ({
             selectedFunction={selectedFunction}
             testCaseIndex={index}
             onDelete={() => onDelete(index)}
-            onRename={(newName: string) => onRename(index, newName)}
+            onRename={() => onRename(index)}
           />
         </div>
       ))}

--- a/vsc-extension/src-views/components/TestCasesList.tsx
+++ b/vsc-extension/src-views/components/TestCasesList.tsx
@@ -9,6 +9,7 @@ import {
   findTestCases,
 } from "../../src-shared/testcases";
 import { testCasesState } from "../shared/state";
+import { useExtensionState } from "./ExtensionState";
 import { GenerateTestCasesButton } from "./GenerateTestCasesButton";
 import { RunButton } from "./RunButton";
 
@@ -28,7 +29,7 @@ export const TestCasesList: FC<Props> = ({
 }) => {
   const { fileName, functionName } = selectedFunction ?? {};
   const [allTestCases, setAllTestCases] = useRecoilState(testCasesState);
-
+  const { rpcProvider } = useExtensionState();
   if (!selectedFunction) {
     return <div />;
   }
@@ -57,6 +58,21 @@ export const TestCasesList: FC<Props> = ({
       onSelect(remainingTestCasesCount - 1);
     }
     setAllTestCases(newAllTestCases);
+  };
+
+  const onRename = async (testCaseIndex: number, newTestName: string) => {
+    if (!fileName) {
+      return;
+    }
+    if (!functionName) {
+      return;
+    }
+    await rpcProvider?.rpc("renameTest", {
+      fileName,
+      functionName,
+      testCaseIndex,
+      newTestName,
+    });
   };
 
   return (
@@ -100,6 +116,7 @@ export const TestCasesList: FC<Props> = ({
             selectedFunction={selectedFunction}
             testCaseIndex={index}
             onDelete={() => onDelete(index)}
+            onRename={(newName: string) => onRename(index, newName)}
           />
         </div>
       ))}

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -4,11 +4,11 @@ import {
   tsNodeToJsonSchema,
 } from "@imaginary-dev/typescript-transformer";
 import ts from "typescript";
+import * as vscode from "vscode";
 import {
   FunctionTestCase,
   SourceFileTestCaseMap,
-} from "vsc-extension/src-shared/source-info";
-import * as vscode from "vscode";
+} from "../src-shared/source-info";
 import {
   blankTestCase,
   findTestCase,

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -340,3 +340,8 @@ function getParamTypes(fn: ts.FunctionDeclaration, sourceFile: ts.SourceFile) {
     });
   return params;
 }
+
+/**
+ * Generic type for RPC interface - can be consumed elsewhere to make typesafe
+ * callers */
+export type ExtensionRpcInterface = ReturnType<typeof makeRpcHandlers>;

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -216,8 +216,15 @@ export function makeRpcHandlers(
       functionName,
       testCaseIndex,
       newTestName,
-    }: TestLocation & { newTestName: string }) {
-      updateTestName(state, fileName, functionName, testCaseIndex, newTestName);
+    }: TestLocation & { newTestName?: string }) {
+      const newName = await vscode.window.showInputBox({
+        prompt: "Enter new name",
+        value: newTestName,
+      });
+      if (newName === undefined) {
+        return;
+      }
+      updateTestName(state, fileName, functionName, testCaseIndex, newName);
     },
   };
 }

--- a/vsc-extension/src/util/source.ts
+++ b/vsc-extension/src/util/source.ts
@@ -76,3 +76,33 @@ export function findNativeFunction(
   }
   return { fn, sourceFile: functionSource.sourceFile };
 }
+
+export function generateFunctionDefinition(
+  nativeSources: SourceFileMap,
+  fileName: string,
+  functionName: string
+) {
+  const functionInfo = findNativeFunction(
+    nativeSources,
+    fileName,
+    functionName
+  );
+  if (!functionInfo) {
+    console.error(
+      `Unable to find function declaration for ${functionName} in ${fileName}`
+    );
+    throw new Error(
+      `Unable to find function declaration for ${functionName} in ${fileName}`
+    );
+  }
+  const { fn: fnDeclaration, sourceFile } = functionInfo;
+
+  const printer = ts.createPrinter();
+  const printed = printer.printNode(
+    ts.EmitHint.Unspecified,
+    fnDeclaration,
+    sourceFile
+  );
+
+  return printed;
+}

--- a/vsc-extension/src/util/source.ts
+++ b/vsc-extension/src/util/source.ts
@@ -77,6 +77,7 @@ export function findNativeFunction(
   return { fn, sourceFile: functionSource.sourceFile };
 }
 
+/** Generate a full function declaration, including comment and function body */
 export function generateFunctionDefinition(
   nativeSources: SourceFileMap,
   fileName: string,

--- a/vsc-extension/src/util/types.ts
+++ b/vsc-extension/src/util/types.ts
@@ -2,3 +2,15 @@ export interface TypedMap<O extends object> extends Map<keyof O, O[keyof O]> {
   set<K extends keyof O>(k: K, v: O[K]): this;
   get<K extends keyof O>(k: K): O[K];
 }
+
+export interface RpcCaller<
+  I extends {
+    [k: string]: (...params: any[]) => Promise<any>;
+  }
+> {
+  rpc: <K extends keyof I, P extends Parameters<I[K]>>(
+    id: K,
+    parameters: P[0],
+    t?: Array<any>
+  ) => Promise<any>;
+}


### PR DESCRIPTION
- rename package, cannot have @-based package names
- clean up rpc handlers a bit
- consolidate some context
- add renameTest call, sharing with other stuff
- make rpc calls typesafe
- fallout from stronger types
- stub out renaming
- fix gap
- fix onrename to show current test name for now
- missing types
