### PR TITLE
Move delete operation to extension

### DIFF
--- a/vsc-extension/src-views/components/GenerateTestCasesButton.tsx
+++ b/vsc-extension/src-views/components/GenerateTestCasesButton.tsx
@@ -16,7 +16,9 @@ export const GenerateTestCasesButton: FC<{
 
   const onRun = async () => {
     try {
-      if (loading) return;
+      if (loading) {
+        return;
+      }
       setLoading(true);
 
       const hasGpt4Support = await rpcProvider?.rpc("hasAccessToModel", {

--- a/vsc-extension/src-views/components/RunButton.tsx
+++ b/vsc-extension/src-views/components/RunButton.tsx
@@ -47,10 +47,10 @@ export const RunButton: FC<{
   // logic to the backend, but that's a lot of work. so: this autoruns any
   // test case that doesn't have current output.
   useEffect(() => {
-    if (!hasTestOutput) {
+    if (!hasTestOutput && !loading) {
       onRun();
     }
-  }, [hasTestOutput, onRun]);
+  }, [hasTestOutput, loading, onRun]);
 
   if (!rpcProvider) {
     return null;

--- a/vsc-extension/src-views/components/TestCasesList.tsx
+++ b/vsc-extension/src-views/components/TestCasesList.tsx
@@ -1,17 +1,12 @@
 import React, { FC } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import {
   FunctionTestCase,
   MaybeSelectedFunction,
   TestOutput,
 } from "../../src-shared/source-info";
-import {
-  deleteFunctionTestCase,
-  findTestCase,
-  deleteTestOutput,
-  findTestCases,
-} from "../../src-shared/testcases";
-import { latestTestOutputState, testCasesState } from "../shared/state";
+import { findTestCase } from "../../src-shared/testcases";
+import { testCasesState } from "../shared/state";
 import { useExtensionState } from "./ExtensionState";
 import { GenerateTestCasesButton } from "./GenerateTestCasesButton";
 import { RunButton } from "./RunButton";
@@ -33,11 +28,8 @@ export const TestCasesList: FC<Props> = ({
   onSelect,
 }) => {
   const { fileName, functionName } = selectedFunction ?? {};
-  const [allTestCases, setAllTestCases] = useRecoilState(testCasesState);
+  const allTestCases = useRecoilValue(testCasesState);
   const { rpcProvider } = useExtensionState();
-  const [allTestOutputs, setTestOutputs] = useRecoilState(
-    latestTestOutputState
-  );
 
   if (!selectedFunction) {
     return <div />;
@@ -55,27 +47,6 @@ export const TestCasesList: FC<Props> = ({
       functionName,
       testCaseIndex: index,
     });
-
-    const newAllTestCases = deleteFunctionTestCase(
-      allTestCases,
-      fileName,
-      functionName,
-      index
-    );
-    const remainingTestCasesCount =
-      findTestCases(newAllTestCases, fileName, functionName)?.testCases
-        .length ?? 0;
-    if (
-      remainingTestCasesCount > 0 &&
-      remainingTestCasesCount >= (selectedIndex ?? -1)
-    ) {
-      onSelect(remainingTestCasesCount - 1);
-    }
-    setAllTestCases(newAllTestCases);
-
-    setTestOutputs(
-      deleteTestOutput(allTestOutputs, fileName, functionName, index)
-    );
   };
 
   const onRename = async (testCaseIndex: number) => {

--- a/vsc-extension/src-views/components/TestCasesList.tsx
+++ b/vsc-extension/src-views/components/TestCasesList.tsx
@@ -50,6 +50,11 @@ export const TestCasesList: FC<Props> = ({
     if (!functionName) {
       return;
     }
+    await rpcProvider?.rpc("deleteTest", {
+      fileName,
+      functionName,
+      testCaseIndex: index,
+    });
 
     const newAllTestCases = deleteFunctionTestCase(
       allTestCases,

--- a/vsc-extension/src-views/components/TestCasesList.tsx
+++ b/vsc-extension/src-views/components/TestCasesList.tsx
@@ -102,7 +102,12 @@ export const TestCasesList: FC<Props> = ({
         >
           {/* special flex + padding to ensure whitespace is clickable, even if test name is blank */}
           <span
-            style={{ flex: 1, paddingRight: "1rem" }}
+            style={{
+              flex: 1,
+              paddingRight: "1rem",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
             onClick={() => onSelect(index)}
           >
             {testCase.name}

--- a/vsc-extension/src-views/function-panel/App.tsx
+++ b/vsc-extension/src-views/function-panel/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { RecoilRoot } from "recoil";
 import { ExtensionStateProvider } from "../components/ExtensionState";
 import { OutputPanel } from "../components/OutputPanel";
@@ -6,13 +6,15 @@ import { RecoilSyncWebview } from "../components/RecoilSyncWebview";
 
 const App = () => {
   return (
-    <RecoilRoot>
-      <ExtensionStateProvider>
-        <RecoilSyncWebview>
-          <OutputPanel />
-        </RecoilSyncWebview>
-      </ExtensionStateProvider>
-    </RecoilRoot>
+    <Suspense fallback={<div>Loading...</div>}>
+      <RecoilRoot>
+        <ExtensionStateProvider>
+          <RecoilSyncWebview>
+            <OutputPanel />
+          </RecoilSyncWebview>
+        </ExtensionStateProvider>
+      </RecoilRoot>
+    </Suspense>
   );
 };
 

--- a/vsc-extension/src-views/input-panel/App.tsx
+++ b/vsc-extension/src-views/input-panel/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { RecoilRoot } from "recoil";
 import { ExtensionStateProvider } from "../components/ExtensionState";
 import { InputPanel } from "../components/InputPanel";
@@ -6,13 +6,15 @@ import { RecoilSyncWebview } from "../components/RecoilSyncWebview";
 
 const App = () => {
   return (
-    <RecoilRoot>
-      <ExtensionStateProvider>
-        <RecoilSyncWebview>
-          <InputPanel />
-        </RecoilSyncWebview>
-      </ExtensionStateProvider>
-    </RecoilRoot>
+    <Suspense fallback={<div>Loading...</div>}>
+      <RecoilRoot>
+        <ExtensionStateProvider>
+          <RecoilSyncWebview>
+            <InputPanel />
+          </RecoilSyncWebview>
+        </ExtensionStateProvider>
+      </RecoilRoot>
+    </Suspense>
   );
 };
 export default App;

--- a/vsc-extension/src/rpc-handlers.ts
+++ b/vsc-extension/src/rpc-handlers.ts
@@ -12,6 +12,8 @@ import {
 } from "../src-shared/source-info";
 import {
   blankTestCase,
+  deleteFunctionTestCase,
+  deleteTestOutput,
   findTestCase,
   updateSourceFileTestCase,
   updateSourceFileTestOutput,
@@ -254,6 +256,36 @@ export function makeRpcHandlers(
         return;
       }
       updateTestName(state, fileName, functionName, testCaseIndex, newName);
+    },
+
+    async deleteTest({ fileName, functionName, testCaseIndex }: TestLocation) {
+      state.set(
+        "testCases",
+        deleteFunctionTestCase(
+          state.get("testCases"),
+          fileName,
+          functionName,
+          testCaseIndex
+        )
+      );
+      state.set(
+        "latestTestOutput",
+        deleteTestOutput(
+          state.get("latestTestOutput"),
+          fileName,
+          functionName,
+          testCaseIndex
+        )
+      );
+      state.set(
+        "acceptedTestOutput",
+        deleteTestOutput(
+          state.get("acceptedTestOutput"),
+          fileName,
+          functionName,
+          testCaseIndex
+        )
+      );
     },
   };
 }


### PR DESCRIPTION
Lets it be more "contained" and independent of the UI

- do not rerun the test case constantly!
- delete tests extension-side
- move the rest of deletion to the extension
- fix overflow
- wrap in suspense to avoid stuck loading
- fix loading state
