### PR TITLE
Debounce state updates that are broadcast to views

### DIFF
--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -106,7 +106,6 @@ export class ReactWebViewProvider<S extends object, R extends BaseRpcHandlers>
       this.dirtyState = newState;
       setImmediate(() => this.flushStateUpdate());
     }
-    return this.rpc("update-state", newState);
   }
 
   async flushStateUpdate() {

--- a/vsc-extension/src/util/react-webview-provider.ts
+++ b/vsc-extension/src/util/react-webview-provider.ts
@@ -111,10 +111,11 @@ export class ReactWebViewProvider<S extends object, R extends BaseRpcHandlers>
 
   async flushStateUpdate() {
     const newState = this.dirtyState;
+    this.dirtyState = null;
     if (!newState) {
       console.warn("flush on empty state");
+      return;
     }
-    this.dirtyState = null;
     await this.rpc("update-state", newState);
   }
 


### PR DESCRIPTION
Debouncing is only done on a single tick, to capture all synchronous state updates, but still be responsive and consistent

- make ImaginaryMessageRouter state-agnostic
- make each webview slightly defer state updates
- do not update in broken dirty state
- do not actually update state separately
