### PR TITLE
Add a drawer for creating a new test

### DIFF
--- a/vsc-extension/src-views/components/Drawer.tsx
+++ b/vsc-extension/src-views/components/Drawer.tsx
@@ -6,6 +6,7 @@ interface Props {
   onClose: () => void;
 
   header?: React.ReactNode;
+  footer?: React.ReactNode;
 }
 
 export const Drawer: FC<PropsWithChildren<Props>> = ({
@@ -13,11 +14,12 @@ export const Drawer: FC<PropsWithChildren<Props>> = ({
   onClose,
   children,
   header,
+  footer,
 }) => {
   return (
     <div
       style={{
-        position: "absolute",
+        position: "fixed",
         left: "0px",
         top: "0px",
         bottom: "0px",
@@ -28,6 +30,8 @@ export const Drawer: FC<PropsWithChildren<Props>> = ({
         borderRightWidth: "1px",
         borderRightStyle: "solid",
         zIndex: "10",
+        display: "flex",
+        flexDirection: "column",
       }}
     >
       <div
@@ -47,7 +51,21 @@ export const Drawer: FC<PropsWithChildren<Props>> = ({
           <span className="codicon codicon-close" />
         </VSCodeButton>
       </div>
-      <div style={{ padding: "1rem" }}>{children}</div>
+      <div style={{ padding: "1rem", flex: 1, overflow: "auto" }}>
+        {children}
+      </div>
+      {footer && (
+        <div
+          style={{
+            padding: "1rem",
+            borderColor: "var(--vscode-widget-border)",
+            borderTopWidth: "1px",
+            borderTopStyle: "solid",
+          }}
+        >
+          {footer}
+        </div>
+      )}
     </div>
   );
 };

--- a/vsc-extension/src-views/components/Drawer.tsx
+++ b/vsc-extension/src-views/components/Drawer.tsx
@@ -1,0 +1,38 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import React, { CSSProperties, FC, PropsWithChildren } from "react";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  minWidth: Exclude<CSSProperties["minWidth"], undefined>;
+  style?: CSSProperties;
+}
+
+export const Drawer: FC<PropsWithChildren<Props>> = ({
+  isOpen,
+  onClose,
+  children,
+  style,
+}) => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        bottom: 0,
+        transition: "transform 0.3s ease",
+        transform: `translateX(${isOpen ? "0%" : "-100%"})`,
+        backgroundColor: "var(--background)",
+        ...style,
+      }}
+    >
+      <div>
+        <VSCodeButton appearance="icon" onClick={onClose}>
+          <span className="codicon codicon-close" />
+        </VSCodeButton>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+};

--- a/vsc-extension/src-views/components/Drawer.tsx
+++ b/vsc-extension/src-views/components/Drawer.tsx
@@ -1,38 +1,53 @@
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
-import React, { CSSProperties, FC, PropsWithChildren } from "react";
+import React, { FC, PropsWithChildren } from "react";
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  minWidth: Exclude<CSSProperties["minWidth"], undefined>;
-  style?: CSSProperties;
+
+  header?: React.ReactNode;
 }
 
 export const Drawer: FC<PropsWithChildren<Props>> = ({
   isOpen,
   onClose,
   children,
-  style,
+  header,
 }) => {
   return (
     <div
       style={{
         position: "absolute",
-        left: 0,
-        top: 0,
-        bottom: 0,
-        transition: "transform 0.3s ease",
+        left: "0px",
+        top: "0px",
+        bottom: "0px",
+        transition: "transform 0.3s ease 0s",
         transform: `translateX(${isOpen ? "0%" : "-100%"})`,
         backgroundColor: "var(--background)",
-        ...style,
+        borderColor: "var(--vscode-widget-border)",
+        borderRightWidth: "1px",
+        borderRightStyle: "solid",
+        zIndex: "10",
       }}
     >
-      <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: "1rem",
+          padding: "1rem",
+          borderColor: "var(--vscode-widget-border)",
+          borderBottomWidth: "1px",
+          borderBottomStyle: "solid",
+        }}
+      >
+        <div>{header}</div>
         <VSCodeButton appearance="icon" onClick={onClose}>
           <span className="codicon codicon-close" />
         </VSCodeButton>
       </div>
-      <div>{children}</div>
+      <div style={{ padding: "1rem" }}>{children}</div>
     </div>
   );
 };

--- a/vsc-extension/src-views/components/ExtensionState.tsx
+++ b/vsc-extension/src-views/components/ExtensionState.tsx
@@ -28,10 +28,7 @@ function useExtensionStateInternal() {
       } satisfies ImaginaryMessage;
       vscodeRef.current?.postMessage(msg);
     });
-    rpcProvider.registerRpcHandler("getViewOrigin", async (payload: string) => {
-      console.log("Handler in view with payload:", payload);
-      return window.origin;
-    });
+
     setRpcProvider(rpcProvider);
     window.addEventListener("message", (event) => {
       const message: ImaginaryMessage = event.data;

--- a/vsc-extension/src-views/components/NewTestDrawer.tsx
+++ b/vsc-extension/src-views/components/NewTestDrawer.tsx
@@ -1,0 +1,47 @@
+import React, { FC, useState } from "react";
+import {
+  FunctionTestCase,
+  SerializableFunctionDeclaration,
+} from "../../src-shared/source-info";
+import { blankTestCase } from "../../src-shared/testcases";
+import { Drawer } from "./Drawer";
+import { TestCaseInputEditor } from "./TestCaseInputEditor";
+
+interface Props {
+  isDrawerOpen: boolean;
+  onCloseDrawer: () => void;
+  fn: SerializableFunctionDeclaration;
+}
+
+export const NewTestDrawer: FC<Props> = ({
+  isDrawerOpen,
+  onCloseDrawer,
+  fn,
+}) => {
+  const [draftTestCase, setDraftTestCase] =
+    useState<FunctionTestCase>(blankTestCase);
+  const onUpdateDraftTestCase = (paramName: string, value: string): void =>
+    setDraftTestCase((prevTestCase) => ({
+      ...prevTestCase,
+      inputs: { ...prevTestCase.inputs, [paramName]: value },
+    }));
+
+  return (
+    <Drawer
+      isOpen={isDrawerOpen}
+      onClose={onCloseDrawer}
+      header={
+        <div>
+          <span style={{ fontWeight: "bold" }}>Add test case for</span>{" "}
+          <code>{fn.name}</code>
+        </div>
+      }
+    >
+      <TestCaseInputEditor
+        fn={fn}
+        functionTestCase={draftTestCase}
+        onUpdateTestCase={onUpdateDraftTestCase}
+      />
+    </Drawer>
+  );
+};

--- a/vsc-extension/src-views/components/NewTestDrawer.tsx
+++ b/vsc-extension/src-views/components/NewTestDrawer.tsx
@@ -1,5 +1,5 @@
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
-import React, { FC, useCallback, useState } from "react";
+import React, { FC, useCallback, useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import {
   FunctionTestCase,
@@ -46,6 +46,15 @@ export const NewTestDrawer: FC<Props> = ({
     onCloseDrawer();
     setDraftTestCase(blankTestCase);
   }, [draftTestCase, onCloseDrawer, selectedFunction, setTestCases, testCases]);
+
+  // Close the drawer whenever the selected function changes
+  useEffect(() => {
+    onCloseDrawer();
+  }, [
+    onCloseDrawer,
+    selectedFunction?.fileName,
+    selectedFunction?.functionName,
+  ]);
 
   return (
     <Drawer

--- a/vsc-extension/src-views/components/NewTestDrawer.tsx
+++ b/vsc-extension/src-views/components/NewTestDrawer.tsx
@@ -1,12 +1,20 @@
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import React, { FC, useCallback, useEffect, useState } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import {
   FunctionTestCase,
   SerializableFunctionDeclaration,
 } from "../../src-shared/source-info";
-import { addFunctionTestCase, blankTestCase } from "../../src-shared/testcases";
-import { selectedFunctionState, testCasesState } from "../shared/state";
+import {
+  addFunctionTestCase,
+  blankTestCase,
+  findTestCases,
+} from "../../src-shared/testcases";
+import {
+  selectedFunctionState,
+  selectedTestCaseIndexState,
+  testCasesState,
+} from "../shared/state";
 import { Drawer } from "./Drawer";
 import { TestCaseInputEditor } from "./TestCaseInputEditor";
 
@@ -23,6 +31,9 @@ export const NewTestDrawer: FC<Props> = ({
 }) => {
   const [testCases, setTestCases] = useRecoilState(testCasesState);
   const selectedFunction = useRecoilValue(selectedFunctionState);
+  const setTestCaseIndex = useSetRecoilState(
+    selectedTestCaseIndexState(selectedFunction)
+  );
   const [draftTestCase, setDraftTestCase] =
     useState<FunctionTestCase>(blankTestCase);
   const onUpdateDraftTestCase = (paramName: string, value: string): void =>
@@ -43,9 +54,28 @@ export const NewTestDrawer: FC<Props> = ({
       draftTestCase
     );
     setTestCases(newTestCases);
+
+    // Find the index of the new test (at the end) and select it
+    const totalTestCases =
+      findTestCases(
+        newTestCases,
+        selectedFunction.fileName,
+        selectedFunction.functionName
+      )?.testCases.length ?? 0;
+    setTestCaseIndex(totalTestCases - 1);
+
     onCloseDrawer();
+
+    // clear out state for the next one
     setDraftTestCase(blankTestCase);
-  }, [draftTestCase, onCloseDrawer, selectedFunction, setTestCases, testCases]);
+  }, [
+    draftTestCase,
+    onCloseDrawer,
+    selectedFunction,
+    setTestCaseIndex,
+    setTestCases,
+    testCases,
+  ]);
 
   // Close the drawer whenever the selected function changes
   useEffect(() => {

--- a/vsc-extension/src-views/components/NewTestDrawer.tsx
+++ b/vsc-extension/src-views/components/NewTestDrawer.tsx
@@ -44,6 +44,7 @@ export const NewTestDrawer: FC<Props> = ({
     );
     setTestCases(newTestCases);
     onCloseDrawer();
+    setDraftTestCase(blankTestCase);
   }, [draftTestCase, onCloseDrawer, selectedFunction, setTestCases, testCases]);
 
   return (

--- a/vsc-extension/src-views/components/NewTestDrawer.tsx
+++ b/vsc-extension/src-views/components/NewTestDrawer.tsx
@@ -1,3 +1,4 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import React, { FC, useState } from "react";
 import {
   FunctionTestCase,
@@ -34,6 +35,11 @@ export const NewTestDrawer: FC<Props> = ({
         <div>
           <span style={{ fontWeight: "bold" }}>Add test case for</span>{" "}
           <code>{fn.name}</code>
+        </div>
+      }
+      footer={
+        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <VSCodeButton>Create test case</VSCodeButton>
         </div>
       }
     >

--- a/vsc-extension/src-views/components/TestCaseDashboard.tsx
+++ b/vsc-extension/src-views/components/TestCaseDashboard.tsx
@@ -18,7 +18,7 @@ import {
   testCasesState,
 } from "../shared/state";
 import { Drawer } from "./Drawer";
-import { ParamEditor } from "./ParamEditor";
+import { TestCaseInputEditor } from "./TestCaseInputEditor";
 import { TestCasesList } from "./TestCasesList";
 import { useToggle } from "./useToggle";
 
@@ -155,33 +155,11 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
             Output
           </div>
 
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.5rem",
-            }}
-          >
-            {functionTestCase &&
-              fn.parameters.map((param) => (
-                <div
-                  key={param.name}
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "0.25rem",
-                  }}
-                >
-                  <ParamEditor
-                    parameter={param}
-                    value={functionTestCase.inputs[param.name]}
-                    onChange={(newValue) =>
-                      onUpdateTestCase(param.name, newValue)
-                    }
-                  />
-                </div>
-              ))}
-          </div>
+          <TestCaseInputEditor
+            functionTestCase={functionTestCase}
+            fn={fn}
+            onUpdateTestCase={onUpdateTestCase}
+          />
 
           <div
             style={{

--- a/vsc-extension/src-views/components/TestCaseDashboard.tsx
+++ b/vsc-extension/src-views/components/TestCaseDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useState } from "react";
+import React, { FC, ReactNode } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import {
   FunctionTestCase,
@@ -17,7 +17,7 @@ import {
   selectedTestCaseIndexState,
   testCasesState,
 } from "../shared/state";
-import { Drawer } from "./Drawer";
+import { NewTestDrawer } from "./NewTestDrawer";
 import { TestCaseInputEditor } from "./TestCaseInputEditor";
 import { TestCasesList } from "./TestCasesList";
 import { useToggle } from "./useToggle";
@@ -78,8 +78,6 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
   const functionTestOutput: TestOutput | undefined =
     testOutputsForSelectedFunction[testIndex];
 
-  const [draftTestCase, setDraftTestCase] =
-    useState<FunctionTestCase>(blankTestCase);
   // if (!functionTestCase) {
   //   console.log("missing functionTestCase for ", testIndex);
   // }
@@ -87,27 +85,11 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
     <>
       <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
         <b style={{ fontSize: "20px" }}>Function:</b>
-        <Drawer
-          isOpen={isDrawerOpen}
-          onClose={onCloseDrawer}
-          header={
-            <div>
-              <span style={{ fontWeight: "bold" }}>Add test case for</span>{" "}
-              <code>{fn.name}</code>
-            </div>
-          }
-        >
-          <TestCaseInputEditor
-            fn={fn}
-            functionTestCase={draftTestCase}
-            onUpdateTestCase={(paramName, value) =>
-              setDraftTestCase((prevTestCase) => ({
-                ...prevTestCase,
-                inputs: { ...prevTestCase.inputs, [paramName]: value },
-              }))
-            }
-          />
-        </Drawer>
+        <NewTestDrawer
+          isDrawerOpen={isDrawerOpen}
+          onCloseDrawer={onCloseDrawer}
+          fn={fn}
+        />
         <div
           style={{
             paddingTop: "0.5rem",

--- a/vsc-extension/src-views/components/TestCaseDashboard.tsx
+++ b/vsc-extension/src-views/components/TestCaseDashboard.tsx
@@ -85,7 +85,16 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
     <>
       <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
         <b style={{ fontSize: "20px" }}>Function:</b>
-        <Drawer isOpen={isDrawerOpen} onClose={onCloseDrawer} minWidth="100px">
+        <Drawer
+          isOpen={isDrawerOpen}
+          onClose={onCloseDrawer}
+          header={
+            <div>
+              <span style={{ fontWeight: "bold" }}>Add test case for</span>{" "}
+              <code>{fn.name}</code>
+            </div>
+          }
+        >
           This is some stuff
         </Drawer>
         <div

--- a/vsc-extension/src-views/components/TestCaseDashboard.tsx
+++ b/vsc-extension/src-views/components/TestCaseDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from "react";
+import React, { FC, ReactNode, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import {
   FunctionTestCase,
@@ -78,6 +78,8 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
   const functionTestOutput: TestOutput | undefined =
     testOutputsForSelectedFunction[testIndex];
 
+  const [draftTestCase, setDraftTestCase] =
+    useState<FunctionTestCase>(blankTestCase);
   // if (!functionTestCase) {
   //   console.log("missing functionTestCase for ", testIndex);
   // }
@@ -95,7 +97,16 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
             </div>
           }
         >
-          This is some stuff
+          <TestCaseInputEditor
+            fn={fn}
+            functionTestCase={draftTestCase}
+            onUpdateTestCase={(paramName, value) =>
+              setDraftTestCase((prevTestCase) => ({
+                ...prevTestCase,
+                inputs: { ...prevTestCase.inputs, [paramName]: value },
+              }))
+            }
+          />
         </Drawer>
         <div
           style={{

--- a/vsc-extension/src-views/components/TestCaseDashboard.tsx
+++ b/vsc-extension/src-views/components/TestCaseDashboard.tsx
@@ -17,8 +17,10 @@ import {
   selectedTestCaseIndexState,
   testCasesState,
 } from "../shared/state";
+import { Drawer } from "./Drawer";
 import { ParamEditor } from "./ParamEditor";
 import { TestCasesList } from "./TestCasesList";
+import { useToggle } from "./useToggle";
 
 interface Props {
   fn: SerializableFunctionDeclaration;
@@ -29,6 +31,12 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
   const [testIndex, setTestIndex] = useRecoilState(
     selectedTestCaseIndexState(selectedFunction)
   );
+  const {
+    onClose: onCloseDrawer,
+    onOpen: onOpenDrawer,
+    isOpen: isDrawerOpen,
+  } = useToggle();
+
   const [testCases, setTestCases] = useRecoilState(testCasesState);
   const testCasesForSelectedFunction =
     findTestCases(
@@ -77,6 +85,9 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
     <>
       <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
         <b style={{ fontSize: "20px" }}>Function:</b>
+        <Drawer isOpen={isDrawerOpen} onClose={onCloseDrawer} minWidth="100px">
+          This is some stuff
+        </Drawer>
         <div
           style={{
             paddingTop: "0.5rem",
@@ -99,6 +110,7 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
           selectedFunction={selectedFunction}
           selectedIndex={testIndex}
           onSelect={setTestIndex}
+          onCreate={onOpenDrawer}
         />
         <div
           style={{

--- a/vsc-extension/src-views/components/TestCaseDashboard.tsx
+++ b/vsc-extension/src-views/components/TestCaseDashboard.tsx
@@ -100,6 +100,8 @@ export const TestCaseDashboard: FC<Props> = ({ fn, selectedFunction }) => {
             borderColor: "var(--checkbox-border)",
             borderWidth: "var(--border-width)",
             borderStyle: "solid",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
           }}
         >
           <code style={{ whiteSpace: "nowrap" }}>{formattedDeclaration}</code>

--- a/vsc-extension/src-views/components/TestCaseInputEditor.tsx
+++ b/vsc-extension/src-views/components/TestCaseInputEditor.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from "react";
+import {
+  FunctionTestCase,
+  SerializableFunctionDeclaration,
+} from "../../src-shared/source-info";
+import { ParamEditor } from "./ParamEditor";
+
+interface Props {
+  functionTestCase: FunctionTestCase;
+  fn: SerializableFunctionDeclaration;
+  onUpdateTestCase: (paramName: string, value: string) => void;
+}
+
+export const TestCaseInputEditor: FC<Props> = ({
+  functionTestCase,
+  fn,
+  onUpdateTestCase,
+}) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.5rem",
+      }}
+    >
+      {functionTestCase &&
+        fn.parameters.map((param) => (
+          <div
+            key={param.name}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.25rem",
+            }}
+          >
+            <ParamEditor
+              parameter={param}
+              value={functionTestCase.inputs[param.name]}
+              onChange={(newValue) => onUpdateTestCase(param.name, newValue)}
+            />
+          </div>
+        ))}
+    </div>
+  );
+};

--- a/vsc-extension/src-views/components/TestCasesList.tsx
+++ b/vsc-extension/src-views/components/TestCasesList.tsx
@@ -1,3 +1,4 @@
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import React, { FC } from "react";
 import { useRecoilValue } from "recoil";
 import {
@@ -17,6 +18,7 @@ interface Props {
   selectedFunction: MaybeSelectedFunction;
   selectedIndex: number | null;
   onSelect: (selectedIndex: number) => void;
+  onCreate: () => void;
 }
 
 // TestCasesList component
@@ -26,6 +28,7 @@ export const TestCasesList: FC<Props> = ({
   selectedIndex,
   selectedFunction,
   onSelect,
+  onCreate,
 }) => {
   const { fileName, functionName } = selectedFunction ?? {};
   const allTestCases = useRecoilValue(testCasesState);
@@ -123,6 +126,7 @@ export const TestCasesList: FC<Props> = ({
         </div>
       ))}
       <GenerateTestCasesButton selectedFunction={selectedFunction} />
+      <VSCodeButton onClick={onCreate}>Add new test</VSCodeButton>
     </div>
   );
 };

--- a/vsc-extension/src-views/components/useToggle.tsx
+++ b/vsc-extension/src-views/components/useToggle.tsx
@@ -1,0 +1,13 @@
+import { useCallback, useState } from "react";
+
+export function useToggle(defaultState = false) {
+  const [isOpen, setIsOpen] = useState(defaultState);
+  const onOpen = useCallback(() => setIsOpen(true), []);
+  const onClose = useCallback(() => setIsOpen(false), []);
+  return {
+    isOpen,
+    setIsOpen,
+    onOpen,
+    onClose,
+  };
+}


### PR DESCRIPTION
Fixes #94

- unused rpc
- stub out drawer
- start styling drawer
- break out testcase editor
- bring in TestCaseInputEditor
- break out drawer, maintain draft there
- add support for a footer
- add create new test button
- unrelated: do not let function overflow
- wire up creation of new test
- make sure to clear the test between
- close the drawer when function changes
- fully create the test and move on
