### PR TITLE
Handle overlap between generating tests and adding new tests

### DIFF
--- a/vsc-extension/src-views/components/GenerateTestCasesButton.tsx
+++ b/vsc-extension/src-views/components/GenerateTestCasesButton.tsx
@@ -24,7 +24,7 @@ export const GenerateTestCasesButton: FC<{
   );
   const { isMutating, trigger: generateTestParameters } = useSWRMutation(
     "generateTestParameters",
-    () => {
+    async () => {
       const testCasesForSelectedFunction =
         findTestCases(
           testCases,
@@ -53,32 +53,20 @@ export const GenerateTestCasesButton: FC<{
         return;
       }
 
-      const newTestCases = await generateTestParameters();
+      const newInputs = await generateTestParameters();
 
-      if (!newTestCases) {
+      if (!newInputs) {
         return;
       }
 
-      let resultTestCases = testCases;
-
-      // this is a little odd, in that we bundle this test case in an array
-      // and then iterate over it. I originally built this as having the function
-      // return an array of test cases, and then we changed it to one at a time. We
-      // might change it back, so I'm leaving it this way for now.
-      [newTestCases].forEach((newTestCase) => {
-        resultTestCases = addFunctionTestCase(
-          resultTestCases,
-          fileName,
-          functionName,
-          {
-            name: newTestCase.__testName ?? "New test",
-            hasCustomName: !!newTestCase.__testName,
-            inputs: Object.assign({}, newTestCase, { __testName: undefined }),
-          }
-        );
+      setTestCases((prevTestCases) => {
+        const { __testName, ...inputs } = newInputs;
+        return addFunctionTestCase(prevTestCases, fileName, functionName, {
+          name: __testName ?? "New test",
+          hasCustomName: !!__testName,
+          inputs,
+        });
       });
-
-      setTestCases(resultTestCases);
     } catch (ex) {
       console.error(`Failure to run: ${ex}`, ex);
     }

--- a/vsc-extension/src-views/components/NewTestDrawer.tsx
+++ b/vsc-extension/src-views/components/NewTestDrawer.tsx
@@ -1,15 +1,11 @@
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import React, { FC, useCallback, useEffect, useState } from "react";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import {
   FunctionTestCase,
   SerializableFunctionDeclaration,
 } from "../../src-shared/source-info";
-import {
-  addFunctionTestCase,
-  blankTestCase,
-  findTestCases,
-} from "../../src-shared/testcases";
+import { addFunctionTestCase, blankTestCase } from "../../src-shared/testcases";
 import {
   selectedFunctionState,
   selectedTestCaseIndexState,
@@ -29,7 +25,7 @@ export const NewTestDrawer: FC<Props> = ({
   onCloseDrawer,
   fn,
 }) => {
-  const [testCases, setTestCases] = useRecoilState(testCasesState);
+  const setTestCases = useSetRecoilState(testCasesState);
   const selectedFunction = useRecoilValue(selectedFunctionState);
   const setTestCaseIndex = useSetRecoilState(
     selectedTestCaseIndexState(selectedFunction)
@@ -47,22 +43,17 @@ export const NewTestDrawer: FC<Props> = ({
       console.warn("Trying to add function but lost selection");
       return;
     }
-    const newTestCases = addFunctionTestCase(
-      testCases,
-      selectedFunction.fileName,
-      selectedFunction.functionName,
-      draftTestCase
-    );
-    setTestCases(newTestCases);
-
-    // Find the index of the new test (at the end) and select it
-    const totalTestCases =
-      findTestCases(
-        newTestCases,
+    setTestCases((prevTestCases) =>
+      addFunctionTestCase(
+        prevTestCases,
         selectedFunction.fileName,
-        selectedFunction.functionName
-      )?.testCases.length ?? 0;
-    setTestCaseIndex(totalTestCases - 1);
+        selectedFunction.functionName,
+        draftTestCase
+      )
+    );
+
+    // new test is added at the top
+    setTestCaseIndex(0);
 
     onCloseDrawer();
 
@@ -74,7 +65,6 @@ export const NewTestDrawer: FC<Props> = ({
     selectedFunction,
     setTestCaseIndex,
     setTestCases,
-    testCases,
   ]);
 
   // Close the drawer whenever the selected function changes

--- a/vsc-extension/src/util/persistence.ts
+++ b/vsc-extension/src/util/persistence.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -49,7 +50,7 @@ async function writeSourceFileTestCases(
 
 async function accessible(path: string) {
   try {
-    await fs.access(path, fs.constants.R_OK);
+    await fs.access(path, fsConstants.R_OK);
     return true;
   } catch {
     return false;

--- a/vsc-extension/src/util/persistence.ts
+++ b/vsc-extension/src/util/persistence.ts
@@ -46,6 +46,15 @@ async function writeSourceFileTestCases(
     JSON.stringify(testCaseFile, null, 2)
   );
 }
+
+async function accessible(path: string) {
+  try {
+    await fs.access(path, fs.constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 export async function loadTestCases(sourceFileName: string): Promise<{
   testCases: SourceFileTestCases;
   testOutputs: SourceFileTestOutput;
@@ -53,6 +62,12 @@ export async function loadTestCases(sourceFileName: string): Promise<{
   const testCaseFileName = getAbsolutePathInProject(
     getTestCaseFilename(sourceFileName)
   );
+  if (!(await accessible(testCaseFileName))) {
+    return {
+      testCases: { sourceFileName, functionTestCases: [] },
+      testOutputs: { sourceFileName, functionOutputs: [] },
+    };
+  }
   try {
     const testCasesRaw = await fs.readFile(testCaseFileName, {
       encoding: "utf-8",


### PR DESCRIPTION
Previously, if you added a test manually while a previous test was running, it would overwrite the 
manual test once the generated test was ready

- switch to using prevTestCases when generating tests
- also use prevTestCases when generating with a click
- make sure to use prevTestCases in drawer as well
- do not warn if file does not exist
